### PR TITLE
Support launching on mybinder.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # vizarr
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hms-dbmi/vizarr/master?filepath=example%2Fgetting_started.ipynb)
 
 ![Multiscale OME-Zarr in Jupyter Notebook with Vizarr](/screenshot.png)
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,17 @@
+name: vizarr
+channels:
+  - conda-forge
+  - defaults
+dependencies:
+  - fsspec
+  - ipywidgets
+  - jupyter-server-proxy
+  - numba
+  - numpy
+  - requests
+  - scikit-image
+  - zarr
+  - pip:
+    - imjoy>=0.10.0
+    - imjoy-jupyter-extension
+    - imjoy-rpc


### PR DESCRIPTION
Add mybinder.org files, and a readme badge

Can be tested on my fork/branch: https://mybinder.org/v2/gh/manics/vizarr/binder?filepath=example%2Fgetting_started.ipynb