### PR TITLE
Add ImJoy demo plugin and badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # vizarr
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hms-dbmi/vizarr/master?filepath=example%2Fgetting_started.ipynb)
+[![launch ImJoy](https://imjoy.io/static/badge/launch-imjoy-badge.svg)](https://imjoy.io/#/app?plugin=https://github.com/hms-dbmi/vizarr/blob/master/example/VizarrDemo.imjoy.html)
 
 ![Multiscale OME-Zarr in Jupyter Notebook with Vizarr](/screenshot.png)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vizarr
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/hms-dbmi/vizarr/master?filepath=example%2Fgetting_started.ipynb)
-[![launch ImJoy](https://imjoy.io/static/badge/launch-imjoy-badge.svg)](https://imjoy.io/#/app?plugin=https://github.com/hms-dbmi/vizarr/blob/master/example/VizarrDemo.imjoy.html)
+[![launch ImJoy](https://imjoy.io/static/badge/launch-imjoy-badge.svg)](https://imjoy.io/#/app?workspace=vizarr&plugin=https://github.com/hms-dbmi/vizarr/blob/master/example/VizarrDemo.imjoy.html)
 
 ![Multiscale OME-Zarr in Jupyter Notebook with Vizarr](/screenshot.png)
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -14,4 +14,4 @@ dependencies:
   - pip:
     - imjoy>=0.10.0
     - imjoy-jupyter-extension
-    - imjoy-rpc>=0.2.9
+    - imjoy-rpc>=0.2.11

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -14,4 +14,4 @@ dependencies:
   - pip:
     - imjoy>=0.10.0
     - imjoy-jupyter-extension
-    - imjoy-rpc
+    - imjoy-rpc>=0.2.9

--- a/example/README.md
+++ b/example/README.md
@@ -33,4 +33,8 @@ This notebook a contains a `vizarr` example visualizing a generic multiscale Zar
 $ jupyter notebook mandelbrot.ipynb
 ```
 
+## Display an Image in an ImJoy Plugin [![launch ImJoy](https://imjoy.io/static/badge/launch-imjoy-badge.svg)](https://imjoy.io/#/app?workspace=vizarr&plugin=https://github.com/hms-dbmi/vizarr/blob/master/example/VizarrDemo.imjoy.html)
+
+This [demo plugin](VizarrDemo.imjoy.html) shows how to build an image visualization plugin with `vizarr` in [ImJoy](https://imjoy.io).
+
 

--- a/example/VizarrDemo.imjoy.html
+++ b/example/VizarrDemo.imjoy.html
@@ -67,28 +67,15 @@ class Plugin:
         pass
 
     async def run(self, ctx):
-        if ctx.data:
-            data = ctx.data
-        else:
-            # use default astronaut image
-            create_ome_zarr("astronaut.zarr") # creates an example OME-Zarr in the current directory
-            multiscale_astronaut = zarr.open("astronaut.zarr", mode="r") # open the zarr created above in jupyter kernel
-
-            # Create Zarr 
-            data = {"images": [ { "source": multiscale_astronaut, "name": "astronaut" } ]} 
+        create_ome_zarr("astronaut.zarr") # creates an example OME-Zarr in the current directory
+        multiscale_astronaut = zarr.open("astronaut.zarr", mode="r") # open the zarr created above in jupyter kernel
         
-        assert "images" in data
-        images = data["images"]
-        view_state = data.get('view_state')
+        # Create Zarr 
+        images = [ { "source": multiscale_astronaut, "name": "astronaut" } ]
 
-        if not isinstance(images, list):
-            images = [images]
-    
         viewer = await api.createWindow(
             type="viv-plugin", src="https://hms-dbmi.github.io/vizarr"
         )
-        if view_state:
-            await viewer.set_view_state(view_state)
         for img in images:
             await viewer.add_image(img)
 

--- a/example/VizarrDemo.imjoy.html
+++ b/example/VizarrDemo.imjoy.html
@@ -1,0 +1,96 @@
+﻿<docs lang="markdown">
+[TODO: write documentation for this plugin.]
+</docs>
+
+<config lang="json">
+{
+  "name": "VizarrDemo",
+  "type": "native-python",
+  "version": "0.1.0",
+  "description": "A demo plugin which uses Vizarr to visualize images",
+  "tags": [],
+  "ui": "",
+  "cover": "",
+  "inputs": null,
+  "outputs": null,
+  "flags": [],
+  "icon": "extension",
+  "api_version": "0.1.8",
+  "env": "",
+  "permissions": [],
+  "requirements": ["repo:https://github.com/hms-dbmi/vizarr.git", "conda: zarr scikit-image"],
+  "dependencies": []
+}
+</config>
+
+<script lang="python">
+import os
+os.chdir('vizarr/example')
+
+from imjoy import api
+import zarr
+from create_fixture import create_ome_zarr
+import zarr
+
+def encode_zarr_store(zobj):
+    path_prefix = f"{zobj.path}/" if zobj.path else ""
+
+    def getItem(key):
+        return zobj.store[path_prefix + key]
+
+    def setItem(key, value):
+        zobj.store[path_prefix + key] = value
+
+    def containsItem(key):
+        if path_prefix + key in zobj.store:
+            return True
+
+    return {
+        "_rintf": True,
+        "_rtype": "zarr-array" if isinstance(zobj, zarr.Array) else "zarr-group",
+        "getItem": getItem,
+        "setItem": setItem,
+        "containsItem": containsItem,
+    }
+
+
+api.registerCodec(
+    {"name": "zarr-array", "type": zarr.Array, "encoder": encode_zarr_store}
+)
+api.registerCodec(
+    {"name": "zarr-group", "type": zarr.Group, "encoder": encode_zarr_store}
+)
+
+
+class Plugin:
+    async def setup(self):
+        pass
+
+    async def run(self, ctx):
+        if ctx.data:
+            data = ctx.data
+        else:
+            # use default astronaut image
+            create_ome_zarr("astronaut.zarr") # creates an example OME-Zarr in the current directory
+            multiscale_astronaut = zarr.open("astronaut.zarr", mode="r") # open the zarr created above in jupyter kernel
+
+            # Create Zarr 
+            data = {"images": [ { "source": multiscale_astronaut, "name": "astronaut" } ]} 
+        
+        assert "images" in data
+        images = data["images"]
+        view_state = data.get('view_state')
+
+        if not isinstance(images, list):
+            images = [images]
+    
+        viewer = await api.createWindow(
+            type="viv-plugin", src="https://hms-dbmi.github.io/vizarr"
+        )
+        if view_state:
+            await viewer.set_view_state(view_state)
+        for img in images:
+            await viewer.add_image(img)
+
+api.export(Plugin())
+</script>

--- a/example/VizarrDemo.imjoy.html
+++ b/example/VizarrDemo.imjoy.html
@@ -74,7 +74,7 @@ class Plugin:
         images = [ { "source": multiscale_astronaut, "name": "astronaut" } ]
 
         viewer = await api.createWindow(
-            type="viv-plugin", src="https://hms-dbmi.github.io/vizarr"
+            type="vizarr", src="https://hms-dbmi.github.io/vizarr"
         )
         for img in images:
             await viewer.add_image(img)

--- a/example/imjoy_plugin.py
+++ b/example/imjoy_plugin.py
@@ -44,7 +44,7 @@ class Plugin:
 
     async def run(self, ctx):
         viewer = await api.createWindow(
-            type="viv-plugin", src="https://hms-dbmi.github.io/vizarr"
+            type="vizarr", src="https://hms-dbmi.github.io/vizarr"
         )
         if self.view_state:
             await viewer.set_view_state(self.view_state)

--- a/example/imjoy_plugin.py
+++ b/example/imjoy_plugin.py
@@ -1,3 +1,4 @@
+import asyncio
 from imjoy import api
 import zarr
 
@@ -23,6 +24,7 @@ def encode_zarr_store(zobj):
         "containsItem": containsItem,
     }
 
+api.init()
 
 api.registerCodec(
     {"name": "zarr-array", "type": zarr.Array, "encoder": encode_zarr_store}
@@ -32,25 +34,18 @@ api.registerCodec(
 )
 
 
-class Plugin:
-    def __init__(self, images, view_state=None):
-        if not isinstance(images, list):
-            images = [images]
-        self.images = images
-        self.view_state = view_state
 
-    async def setup(self):
-        pass
-
-    async def run(self, ctx):
-        viewer = await api.createWindow(
-            type="viv-plugin", src="https://hms-dbmi.github.io/vizarr"
-        )
-        if self.view_state:
-            await viewer.set_view_state(self.view_state)
-        for img in self.images:
-            await viewer.add_image(img)
+async def run_vizarr_async(images, view_state=None):
+    if not isinstance(images, list):
+        images = [images]
+    viewer = await api.createWindow(
+        type="vizarr", src="https://hms-dbmi.github.io/vizarr"
+    )
+    if view_state:
+        await viewer.set_view_state(view_state)
+    for img in images:
+        await viewer.add_image(img)
 
 
 def run_vizarr(images, view_state=None):
-    api.export(Plugin(images, view_state))
+    asyncio.ensure_future(run_vizarr_async(images, view_state))

--- a/example/imjoy_plugin.py
+++ b/example/imjoy_plugin.py
@@ -1,4 +1,3 @@
-import asyncio
 from imjoy import api
 import zarr
 
@@ -24,7 +23,6 @@ def encode_zarr_store(zobj):
         "containsItem": containsItem,
     }
 
-api.init()
 
 api.registerCodec(
     {"name": "zarr-array", "type": zarr.Array, "encoder": encode_zarr_store}
@@ -34,18 +32,25 @@ api.registerCodec(
 )
 
 
+class Plugin:
+    def __init__(self, images, view_state=None):
+        if not isinstance(images, list):
+            images = [images]
+        self.images = images
+        self.view_state = view_state
 
-async def run_vizarr_async(images, view_state=None):
-    if not isinstance(images, list):
-        images = [images]
-    viewer = await api.createWindow(
-        type="vizarr", src="https://hms-dbmi.github.io/vizarr"
-    )
-    if view_state:
-        await viewer.set_view_state(view_state)
-    for img in images:
-        await viewer.add_image(img)
+    async def setup(self):
+        pass
+
+    async def run(self, ctx):
+        viewer = await api.createWindow(
+            type="viv-plugin", src="https://hms-dbmi.github.io/vizarr"
+        )
+        if self.view_state:
+            await viewer.set_view_state(self.view_state)
+        for img in self.images:
+            await viewer.add_image(img)
 
 
 def run_vizarr(images, view_state=None):
-    asyncio.ensure_future(run_vizarr_async(images, view_state))
+    api.export(Plugin(images, view_state))

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -3,7 +3,7 @@ ipywidgets>=7.0.0
 scikit-image
 imjoy>=0.10.0
 fsspec
-imjoy-rpc
+imjoy-rpc>=0.2.9
 zarr
 numba
 requests

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -3,7 +3,7 @@ ipywidgets>=7.0.0
 scikit-image
 imjoy>=0.10.0
 fsspec
-imjoy-rpc>=0.2.9
+imjoy-rpc>=0.2.11
 zarr
 numba
 requests

--- a/multimodal_registration_vizarr.ipynb
+++ b/multimodal_registration_vizarr.ipynb
@@ -673,7 +673,7 @@
     "\n",
     "    async def run(self, ctx):\n",
     "        viewer = await api.createWindow(\n",
-    "            type=\"viv-plugin\",\n",
+    "            type=\"vizarr\",\n",
     "            src=\"https://hms-dbmi.github.io/vizarr/\"\n",
     "        )\n",
     "        for img in self.images:\n",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "deck.gl": "^8.2.4",
-    "imjoy-rpc": "^0.2.19",
+    "imjoy-rpc": "^0.2.20",
     "next": "^9.5.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "deck.gl": "^8.2.4",
-    "imjoy-rpc": "^0.2.20",
+    "imjoy-rpc": "^0.2.22",
     "next": "^9.5.1",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useSetRecoilState } from 'recoil';
 
+import { version as vizarrVersion } from '../../package.json';
 import { layerIdsState, sourceInfoState, viewerViewState } from '../state';
 
 const Viewer = dynamic(() => import('../components/Viewer'));
@@ -37,7 +38,11 @@ function App() {
   useEffect(() => {
     async function initImjoy() {
       const { setupRPC } = await import('imjoy-rpc');
-      const api = await setupRPC({ name: 'viv-plugin' });
+      const api = await setupRPC({ 
+        name: 'vizarr',
+        description: 'A minimal, purely client-side program for viewing Zarr-based images with Viv & ImJoy',
+        version: vizarrVersion,
+      });
       const add_image = async (props) => addImage(props);
       const set_view_state = async (vs) => setViewState(vs);
       api.export({ add_image, set_view_state });


### PR DESCRIPTION
This PR add a imjoy demo plugin which can be installed by click the "launch ImJoy" badge.
It also change the imjoy plugin name to from `viv-plugin` to `vizarr`, add other meta information which will show up in the plugin installation dialog in ImJoy. 

Try with this button: [![launch ImJoy](https://imjoy.io/static/badge/launch-imjoy-badge.svg)](https://imjoy.io/#/app?workspace=viv&plugin=https://github.com/oeway/vizarr/blob/master/example/VizarrDemo.imjoy.html)

The demo plugin is taken from the getting started notebook, it would be cool if we can later build an ImJoy plugin for running the image registration workflow.