### PR TITLE
Bump imjoy-rpc to 0.2.12

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -14,4 +14,4 @@ dependencies:
   - pip:
     - imjoy>=0.10.0
     - imjoy-jupyter-extension
-    - imjoy-rpc>=0.2.9
+    - imjoy-rpc>=0.2.12

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -14,4 +14,4 @@ dependencies:
   - pip:
     - imjoy>=0.10.0
     - imjoy-jupyter-extension
-    - imjoy-rpc>=0.2.11
+    - imjoy-rpc>=0.2.9

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -3,7 +3,7 @@ ipywidgets>=7.0.0
 scikit-image
 imjoy>=0.10.0
 fsspec
-imjoy-rpc>=0.2.11
+imjoy-rpc>=0.2.9
 zarr
 numba
 requests

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -3,7 +3,7 @@ ipywidgets>=7.0.0
 scikit-image
 imjoy>=0.10.0
 fsspec
-imjoy-rpc>=0.2.9
+imjoy-rpc>=0.2.12
 zarr
 numba
 requests


### PR DESCRIPTION
@oeway binder examples are breaking on `master` now. It seems `0.2.11` isn't on pypi?

```
ERROR: Could not find a version that satisfies the requirement imjoy-rpc>=0.2.11 (from -r /home/jovyan/binder/condaenv.4rb1d6ka.req
```