### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+example/* linguist-vendored


### PR DESCRIPTION
The Jupyter notebook examples distort the language stats for the repo, hiding the fact that the source is primarily JavaScript/TypeScript. This PR adds a `.gitattributes` file and marks `example/` as vendored so it is not counted in the repo statistics. 

The multimodal registration notebook will still be included and counted, however, so there will at least be an indicator that Jupyter Notebooks are in the repository.