### PR TITLE
Adjust slider handle by 1px

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -45,6 +45,7 @@ export default createMuiTheme({
         height: 11,
         width: 5,
         borderRadius: '15%',
+        marginLeft: -1,
       },
     },
     MuiInput: {


### PR DESCRIPTION
@mccalluc pointed out that the slider handles appear to be offset by a pixel. It _seems_ that the handles aren't exactly centered perfectly in material-ui, and when we narrowed width of the sliders it revealed this mis-alignment. 

Before:
<img width="134" alt="Screen Shot 2020-09-14 at 11 45 00 AM" src="https://user-images.githubusercontent.com/24403730/93110455-54148100-f683-11ea-9804-fc73d907ac55.png">

After:
<img width="120" alt="image" src="https://user-images.githubusercontent.com/24403730/93110402-42cb7480-f683-11ea-9a4d-eb8c27159a2d.png">
