### PR TITLE
Upgrade imjoy and imjoy-rpc

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,9 +1,9 @@
 numpy
 ipywidgets>=7.0.0
 scikit-image
-imjoy>=0.10.0
+imjoy>=0.10.10
 fsspec
-imjoy-rpc>=0.2.12
+imjoy-rpc>=0.2.30
 zarr
 numba
 requests


### PR DESCRIPTION
In a recent PR in imjoy-rpc (https://github.com/imjoy-team/imjoy-rpc/pull/63), we improved the transport layer for google colab substantially and it would be better to pin imjoy and imjoy-rpc to the new version.