### PR TITLE
Publish to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ out/*
 example/*.zarr
 example/.ipynb_checkpoints/*
 example/data/**
+
+404.html
+index.html
+_next/

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,3 @@ out/*
 example/*.zarr
 example/.ipynb_checkpoints/*
 example/data/**
-
-404.html
-index.html
-_next/

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,14 @@
 const path = require('path');
+const pkg = require('./package.json');
+
+function getAssetPrefix() {
+  if (process.env.GITHUB_JOB === 'build-and-deploy') return '/vizarr/';
+  if (process.env.NPM_BUILD) return `/${pkg.name}@${pkg.version}/`;
+  return '';
+}
 
 module.exports = {
-  assetPrefix:  process.env.GITHUB_JOB === 'build-and-deploy' ? '/vizarr/' : '',
+  assetPrefix:  getAssetPrefix(),
   webpack: config => {
     config.resolve.alias['viv'] = path.resolve(
       __dirname, './node_modules/@hms-dbmi/viv/dist/bundle.es.js'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hms-dbmi/vizarr",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hms-dbmi/vizarr",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "vizarr",
-  "version": "0.0.1",
+  "name": "@hms-dbmi/vizarr",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@hms-dbmi/vizarr",
-  "version": "0.0.3",
-  "private": true,
+  "version": "0.0.4",
   "dependencies": {
     "@hms-dbmi/viv": "^0.4.2",
     "@material-ui/core": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hms-dbmi/vizarr",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "dependencies": {
     "@hms-dbmi/viv": "^0.4.2",
     "@material-ui/core": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vizarr",
-  "version": "0.0.1",
+  "name": "@hms-dbmi/vizarr",
+  "version": "0.0.3",
   "private": true,
   "dependencies": {
     "@hms-dbmi/viv": "^0.4.2",
@@ -18,8 +18,15 @@
     "dev": "next",
     "build": "next build",
     "start": "next start",
-    "export": "next build && next export"
+    "export": "next build && next export",
+    "prepublishOnly": "NPM_BUILD=true npm run export && cp -r ./out/* .",
+    "postpublish": "git clean -fd"
   },
+  "files": [
+    "index.html",
+    "404.html",
+    "_next/"
+  ],
   "prettier": {
     "trailingComma": "es5",
     "printWidth": 120,


### PR DESCRIPTION
Addresses #38. 

Had some trouble with configuring the static assets for `unpkg` (all routes need to be prefixed with `@hms-dbmi/vizarr/@<version>`) but it seems to be working now. What do you think, @oeway ?

https://unpkg.com/@hms-dbmi/vizarr@0.0.4/index.html