### PR TITLE
Revert zarr.js 0.3.1 -> 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7973,12 +7973,13 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "zarr": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.3.1.tgz",
-      "integrity": "sha512-M0/Qv3IYb0zgxrL6EWQgnS/CNnSggBaybEfi9Bc8eWakJa6Hr+JN/NDGJZIqyd8NgqoW2to3S6VGcIwuMIgTQQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.3.0.tgz",
+      "integrity": "sha512-LKT2PugbaySj3M7i/bYIIr1eN4mvBYSrveWuTQK+2ZRgDjqNzt8va0rNCIv3s9dXfJhIIKrvUyftPrJG3lj/Fg==",
       "requires": {
         "numcodecs": "^0.1.0",
         "p-queue": "6.2.0",
+        "pako": "^1.0.11",
         "ts-interface-checker": "^0.1.10"
       }
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "recoil": "0.0.13",
-    "zarr": "^0.3.1"
+    "zarr": "^0.3.0"
   },
   "scripts": {
     "dev": "next",


### PR DESCRIPTION
Fixes: #46 

It turns out the new `HTTPStore` implementation in Zarr.js (https://github.com/gzuidhof/zarr.js/pull/58) introduced a bug that changed CORS in vizarr. The new store lets you manually pass `fetchOptions` to `fetch(url, fetchOptions)`, and defaults to an empty object `{}` if `fecthOptions` isn't provided (rather than undefined).

My guess is that `fetch` has reasonable defaults if not provided, and we overrode this behavior with an explicit empty object.  