### PR TITLE
VIZARR_PREFIX can be set in `npm run export` to customise prefix

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,11 @@ const path = require('path');
 const pkg = require('./package.json');
 
 function getAssetPrefix() {
+  if (process.env.VIZARR_PREFIX) {
+    if (process.env.VIZARR_PREFIX.endsWith("/")) return process.env.VIZARR_PREFIX;
+    return process.env.VIZARR_PREFIX + "/";
+  }
+  url += url.endsWith("/") ? "" : "/"
   if (process.env.GITHUB_JOB === 'build-and-deploy') return '/vizarr/';
   if (process.env.NPM_BUILD) return `/${pkg.name}@${pkg.version}/`;
   return '';

--- a/next.config.js
+++ b/next.config.js
@@ -2,11 +2,7 @@ const path = require('path');
 const pkg = require('./package.json');
 
 function getAssetPrefix() {
-  if (process.env.VIZARR_PREFIX) {
-    if (process.env.VIZARR_PREFIX.endsWith("/")) return process.env.VIZARR_PREFIX;
-    return process.env.VIZARR_PREFIX + "/";
-  }
-  url += url.endsWith("/") ? "" : "/"
+  if (process.env.VIZARR_PREFIX) return process.env.VIZARR_PREFIX;
   if (process.env.GITHUB_JOB === 'build-and-deploy') return '/vizarr/';
   if (process.env.NPM_BUILD) return `/${pkg.name}@${pkg.version}/`;
   return '';


### PR DESCRIPTION
This allows vizarr to be installed under prefixes other than the top level.

For instance, you could run multiple development versions on the same web-server for demo purposes.

```
VIZARR_PREFIX=/vizarr/test-prefix npm run export
```
`cp -a ./out/*` to the location on your webserver corresponding to the URL path `/vizarr/test-prefix`