### PR TITLE
Bump GH-Pages deployment

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -18,7 +18,7 @@ jobs:
           npm run export && touch out/.nojekyll
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.5.9
+        uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages


### PR DESCRIPTION
Need to bump action because of deprecations of `set-env` in Github Actions runners.

https://github.com/JamesIves/github-pages-deploy-action/issues/500
