### PR TITLE
Include pathname in new URLs for Plate/Well onClick

### DIFF
--- a/src/components/LayerController/AcquisitionController.tsx
+++ b/src/components/LayerController/AcquisitionController.tsx
@@ -18,7 +18,7 @@ function AcquisitionController({ layerId }: {layerId: string,}): JSX.Element | n
     const handleSelectionChange = (event: ChangeEvent<HTMLSelectElement>) => {
         let value = event.target.value;
         let acquisition = value === '-1' ? '' : `&acquisition=${value}`
-        window.location.href = window.location.origin + `?source=${source}${acquisition}`;
+        window.location.href = window.location.origin + window.location.pathname + `?source=${source}${acquisition}`;
     };
 
     return (

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -88,7 +88,7 @@ export async function loadOMEWell(config: ImageLayerConfig, store: HTTPStore, ro
         if (typeof source === 'string' && !isNaN(row) && !isNaN(column)) {
             const field = (row * cols) + column;
             let imgSource = join(source, imagePaths[field]);
-            window.open(window.location.origin + '?source=' + imgSource);
+            window.open(window.location.origin + window.location.pathname + '?source=' + imgSource);
         }
     });
 
@@ -169,7 +169,7 @@ export async function loadOMEPlate(
         let { source } = sourceData;
         if (typeof source === 'string' && !isNaN(row) && !isNaN(column)) {
             const imgSource = join(source, acquisitionPath, rowNames[row], columnNames[column]);
-            window.open(window.location.origin + '?source=' + imgSource);
+            window.open(window.location.origin + window.location.pathname + '?source=' + imgSource);
         }
     })
     return sourceData;


### PR DESCRIPTION
This fixes #52.

Adds the missing `window.location.pathname` (e.g. `/vizarr` for https://hms-dbmi.github.io/vizarr to fix the 404 when you click on a Plate or Well.

I missed this before because the `pathname` is empty during development or temp deploys.