### PR TITLE
Ensure source URL is decoded in history

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -30,9 +30,16 @@ function App() {
   }
 
   useEffect(() => {
+    // If a source is provided in the URL, pass all params to load image.
     if ('source' in router.query) {
-      // If a source is provided in the URL, pass all params to load image.
+      // Make sure the source URL is decoded.
+      router.query.source = decodeURIComponent(router.query.source as string);
       addImage((router.query as unknown) as ImageLayerConfig);
+
+      // Update URL in history with correctly encoded source url.
+      const href = new URL(window.location.href);
+      href.searchParams.set('source', router.query.source);
+      window.history.pushState(null, "", decodeURIComponent(href.toString()));
     }
   }, [router]);
 


### PR DESCRIPTION
(Hopefully) fixes #55. Uses [`window.history.pushState`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) to update the `source` URL with a properly decoded url string. 

Since this normalization is done client-side, it shouldn't matter how different hosts (e.g. gh-pages, netlify) choose to encode URL query parameters.

cc: @will-moore 

This PR (decodes provided url): 

https://deploy-preview-56--vizarr.netlify.app?source=https%3A%2F%2Fstorage.googleapis.com%2Fvitessce-demo-data%2Ftest-data%2Fspraggins_ome.zarr

current build on `master` (does not update url): 

https://hms-dbmi.github.io/vizarr/?source=https%3A%2F%2Fstorage.googleapis.com%2Fvitessce-demo-data%2Ftest-data%2Fspraggins_ome.zarr