### PR TITLE
Remove layer from the info object passed to onClick

### DIFF
--- a/src/ome.ts
+++ b/src/ome.ts
@@ -78,7 +78,12 @@ export async function loadOMEWell(config: ImageLayerConfig, store: HTTPStore, ro
     sourceData.name = `Well ${row}${col}`;
     sourceData.rows = Math.ceil(imagePaths.length / cols);
     sourceData.columns = cols;
-    sourceData.onClick = config.onClick || ((info: any) => {
+    sourceData.onClick = ((info: any) => {
+        if(config.onClick) {
+            delete info.layer;
+            config.onClick(info);
+            return;
+        }
         let gridCoord = info.gridCoord;
         if (!gridCoord) {
             return;
@@ -160,7 +165,12 @@ export async function loadOMEPlate(
     sourceData.rows = rows;
     sourceData.columns = columns;
     // Us onClick from image config or Open Well in new window
-    sourceData.onClick = config.onClick || ((info: any) => {
+    sourceData.onClick = ((info: any) => {
+        if(config.onClick) {
+            delete info.layer;
+            config.onClick(info);
+            return;
+        }
         let gridCoord = info.gridCoord;
         if (!gridCoord) {
             return;

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -78,24 +78,27 @@ export async function loadOMEWell(config: ImageLayerConfig, store: HTTPStore, ro
     sourceData.name = `Well ${row}${col}`;
     sourceData.rows = Math.ceil(imagePaths.length / cols);
     sourceData.columns = cols;
-    sourceData.onClick = ((info: any) => {
-        if(config.onClick) {
-            delete info.layer;
-            config.onClick(info);
-            return;
-        }
+    sourceData.onClick = (info: any) => {
         let gridCoord = info.gridCoord;
         if (!gridCoord) {
             return;
         }
         const { row, column } = gridCoord;
         const { source } = sourceData;
+        let imgSource = undefined;
         if (typeof source === 'string' && !isNaN(row) && !isNaN(column)) {
             const field = (row * cols) + column;
-            let imgSource = join(source, imagePaths[field]);
+            imgSource = join(source, imagePaths[field]);
+        }
+        if (config.onClick) {
+            delete info.layer;
+            info.imageSource = imgSource;
+            config.onClick(info);
+        }
+        else if (imgSource){
             window.open(window.location.origin + window.location.pathname + '?source=' + imgSource);
         }
-    });
+    }
 
     return sourceData;
 }
@@ -165,23 +168,27 @@ export async function loadOMEPlate(
     sourceData.rows = rows;
     sourceData.columns = columns;
     // Us onClick from image config or Open Well in new window
-    sourceData.onClick = ((info: any) => {
-        if(config.onClick) {
-            delete info.layer;
-            config.onClick(info);
-            return;
-        }
+    sourceData.onClick = (info: any) => {
         let gridCoord = info.gridCoord;
         if (!gridCoord) {
             return;
         }
         const { row, column } = gridCoord;
         let { source } = sourceData;
+        let imgSource = undefined;
         if (typeof source === 'string' && !isNaN(row) && !isNaN(column)) {
-            const imgSource = join(source, acquisitionPath, rowNames[row], columnNames[column]);
+            imgSource = join(source, acquisitionPath, rowNames[row], columnNames[column]);
+        }
+        if (config.onClick) {
+            delete info.layer;
+            info.imageSource = imgSource;
+            config.onClick(info);
+        }
+        else if (imgSource){
             window.open(window.location.origin + window.location.pathname + '?source=' + imgSource);
         }
-    })
+
+    }
     return sourceData;
 }
 


### PR DESCRIPTION
This is necessary because when the `onClick` function is provided via imjoy-rpc, it cannot encode the layer object. Otherwise we need to register an encoder for the layer object.

Tested with the following code in js:
```js
api.createWindow({src: "http://localhost:3000/", name: "vizarr"}).then((viewer)=>{
    viewer.add_image({_rintf:true, source: "https://minio-dev.openmicroscopy.org/idr/idr0001-graml-sysgro/JL_120731_S6A/pr_45/2551.zarr", name: "Demo Image", onClick: (info)=>{
        console.log(info)
    }})
})
```