### PR TITLE
Handle Z-downsample.

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -58,7 +58,7 @@ export class ZarrLoader extends _ZarrLoader {
     return { data, width, height };
   }
 
-  async getTile(selection: TileSelection) {
+  async getTile(selection: TileSelection): Promise<SelectionData> {
     const { x, y, z, loaderSelection } = selection;
     const source = this._getSource(z); // returns ZarrArray (z is pyramidal level)
     const [xIndex, yIndex] = ['x', 'y'].map(k => this._dimIndices.get(k) as number); // returns axis index for x and y
@@ -79,10 +79,10 @@ export class ZarrLoader extends _ZarrLoader {
       // selection is now ~ [number, number, number, slice(), slice()];
       return source.getRaw(selection);
     });
-    const data = (await Promise.all(dataRequests)) as RawArray[];
+    const data = await Promise.all(dataRequests);
     const { shape: [height, width] } = data[0] as any; // get dims from first image
     return {
-      data: data.map(d => d.data), // extract TypedArray data
+      data: data.map(d => (d as any).data as TypedArray), // extract TypedArray data
       width,
       height
     };

--- a/src/state.ts
+++ b/src/state.ts
@@ -1,6 +1,7 @@
 import { atom, atomFamily, selector, waitForAll } from 'recoil';
 import type { HTTPStore } from 'zarr';
-import type { VivLayerProps, ImageLayer, MultiscaleImageLayer, ZarrLoader } from '@hms-dbmi/viv';
+import type { VivLayerProps, ImageLayer, MultiscaleImageLayer } from '@hms-dbmi/viv';
+import type { ZarrLoader } from './io';
 
 export const DEFAULT_VIEW_STATE = { zoom: 0, target: [0, 0, 0], default: true };
 export const DEFAULT_LAYER_PROPS = {

--- a/types/viv.d.ts
+++ b/types/viv.d.ts
@@ -1,8 +1,9 @@
 declare module '@hms-dbmi/viv' {
   import type { Layer } from '@deck.gl/core';
   import type { ZarrArray } from 'zarr';
+  import type { Slice } from 'zarr/dist/types/core/types';
 
-  type TypedArray = Uint8Array | Uint16Array | Uint32Array | Float32Array;
+  export type TypedArray = Uint8Array | Uint16Array | Uint32Array | Float32Array;
   type SupportedDtype = '<u1' | '<u2' | '<u4' | '<f4';
 
   type DtypeLookup = {
@@ -46,12 +47,16 @@ declare module '@hms-dbmi/viv' {
     readonly tileSize: number;
     readonly dtype: SupportedDtype;
     readonly base: ZarrArray;
+    readonly _dimIndices: Map<string, number>;
 
     getTile(selection: TileSelection): Promise<SelectionData>;
     getRaster(selection: RasterSelection): Promise<SelectionData>;
     getRasterSize(selection: RasterSelection): { width: number; height: number };
 
     onTileError(error: Error): void;
+
+    _getSource(z: any): ZarrArray;
+    _serializeSelection(sel: number[]): (number | null | Slice)[];
   }
 
   export type VivLayerProps = {


### PR DESCRIPTION
This uses the fix suggested by @manzt at #60 to handle Pyramids where each level is downsampled in Z (as well as X and Y).

I have also overridden `ZarrLoader.getRaster()` as well as `getTile()`.

In addition to the suggested fix, I also needed to set the selection[zIndex] to be within the bounds of shape[zIndex] for the current resolution level.

This doesn't change the vizarr UI. The Z-slider still has the full number of steps, even when you're viewing a resolution level that has a smaller number of Z-sections. E.g. if the downsample factor in Z is 2, then level 1 will have size-Z / 2 and the image will only change for every 2 steps of the Z-slider (although we load the data each time) which is not optimal but I don't know how to update the size-Z and Z-slider while you're zooming from one resolution to the next, and at least this works. 

Tested with data generated as at https://github.com/ome/ome-zarr-py/pull/71#issuecomment-759404371
I'll try and get that data to be publicly available for testing ASAP.