### PR TITLE
Add experimental FileReferenceStore

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -59,7 +59,6 @@ function loadSingleChannel(config: SingleChannelConfig, data: ZarrPixelSource<st
 function loadMultiChannel(config: MultichannelConfig, data: ZarrPixelSource<string[]>[], max: number): SourceData {
   const { names, channel_axis, name, model_matrix, opacity = 1, colormap = '' } = config;
   let { contrast_limits, visibilities, colors } = config;
-
   const n = data[0].shape[channel_axis as number];
   for (const channelProp of [contrast_limits, visibilities, names, colors]) {
     if (channelProp && channelProp.length !== n) {
@@ -101,7 +100,7 @@ function loadMultiChannel(config: MultichannelConfig, data: ZarrPixelSource<stri
   return {
     loader: data,
     name,
-    channel_axis: channel_axis as number,
+    channel_axis: Number(channel_axis as number),
     colors,
     names: names ?? range(n).map((i) => `channel_${i}`),
     contrast_limits: contrast_limits ?? Array(n).fill([0, max]),

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -22,15 +22,17 @@ export class FileReferenceStore implements AsyncStore<ArrayBuffer> {
     throw Error('Protocol not supported, got: ' + JSON.stringify(protocol));
   }
 
-  _fetch({ url, offset, size }: { url: string; offset?: number; size?: number }) {
-    const init: RequestInit = {};
+  _fetch({ url, offset, size }: { url: string; offset?: number; size?: number }, opt: RequestInit) {
     if (offset && size) {
-      init.headers = { Range: `bytes=${offset}-${offset + size - 1}` };
+      opt.headers = {
+        ...opt.headers,
+        Range: `bytes=${offset}-${offset + size - 1}`,
+      };
     }
-    return fetch(this._url(url), init);
+    return fetch(this._url(url), opt);
   }
 
-  async getItem(key: string) {
+  async getItem(key: string, opts: RequestInit = {}) {
     const entry = this.ref.get(key);
 
     if (!entry) {
@@ -43,7 +45,7 @@ export class FileReferenceStore implements AsyncStore<ArrayBuffer> {
     }
 
     const [url, offset, size] = entry;
-    const res = await this._fetch({ url, offset, size });
+    const res = await this._fetch({ url, offset, size }, opts);
 
     if (res.status === 200 || res.status === 206) {
       return res.arrayBuffer();

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,70 @@
+import type { AsyncStore } from 'zarr/types/storage/types';
+import { KeyError, HTTPError } from 'zarr';
+
+type Ref = string | [url: string] | [url: string, offset: number, length: number];
+
+const encoder = new TextEncoder();
+
+export class FileReferenceStore implements AsyncStore<ArrayBuffer> {
+  constructor(public ref: Map<string, Ref>) {}
+
+  static async fromUrl(url: string) {
+    const json: Record<string, Ref> = await fetch(url).then((res) => res.json());
+    const ref = new Map(Object.entries(json));
+    return new FileReferenceStore(ref);
+  }
+
+  _url(url: string) {
+    const [protocol, _path] = url.split('://');
+    if (protocol === 'https' || protocol === 'http') {
+      return url;
+    }
+    throw Error('Protocol not supported, got: ' + JSON.stringify(protocol));
+  }
+
+  _fetch({ url, offset, size }: { url: string; offset?: number; size?: number }) {
+    const init: RequestInit = {};
+    if (offset && size) {
+      init.headers = { Range: `bytes=${offset}-${offset + size - 1}` };
+    }
+    return fetch(this._url(url), init);
+  }
+
+  async getItem(key: string) {
+    const entry = this.ref.get(key);
+
+    if (!entry) {
+      throw new KeyError(key);
+    }
+
+    if (typeof entry === 'string') {
+      // JSON data entry in reference
+      return encoder.encode(entry).buffer;
+    }
+
+    const [url, offset, size] = entry;
+    const res = await this._fetch({ url, offset, size });
+
+    if (res.status === 200 || res.status === 206) {
+      return res.arrayBuffer();
+    }
+
+    throw new HTTPError(`Request unsuccessful for key ${key}. Response status: ${res.status}.`);
+  }
+
+  async containsItem(key: string) {
+    return this.ref.has(key);
+  }
+
+  keys() {
+    return Promise.resolve([...this.ref.keys()]);
+  }
+
+  setItem(key: string, value: ArrayBuffer): never {
+    throw Error('FileReferenceStore.setItem is not implemented.');
+  }
+
+  deleteItem(key: string): never {
+    throw Error('FileReferenceStore.deleteItem is not implemented.');
+  }
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -10,6 +10,9 @@ export class FileReferenceStore implements AsyncStore<ArrayBuffer> {
 
   static async fromUrl(url: string) {
     const json: Record<string, Ref> = await fetch(url).then((res) => res.json());
+    if ('version' in json) {
+      throw Error('Only v0 ReferenceFileSystem description is currently supported!');
+    }
     const ref = new Map(Object.entries(json));
     return new FileReferenceStore(ref);
   }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -22,14 +22,12 @@ export class FileReferenceStore implements AsyncStore<ArrayBuffer> {
     throw Error('Protocol not supported, got: ' + JSON.stringify(protocol));
   }
 
-  _fetch({ url, offset, size }: { url: string; offset?: number; size?: number }, opt: RequestInit) {
-    if (offset && size) {
-      opt.headers = {
-        ...opt.headers,
-        Range: `bytes=${offset}-${offset + size - 1}`,
-      };
+  _fetch({ url, offset, size }: { url: string; offset?: number; size?: number }, opts: RequestInit) {
+    if (offset !== undefined && size !== undefined) {
+      // add range headers to request options
+      opts = { ...opts, headers: { ...opts.headers, Range: `bytes=${offset}-${offset + size - 1}` } };
     }
-    return fetch(this._url(url), opt);
+    return fetch(this._url(url), opts);
   }
 
   async getItem(key: string, opts: RequestInit = {}) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,12 +23,12 @@ async function normalizeStore(source: string | ZarrArray['store']) {
   if (typeof source === 'string') {
     if (source.endsWith('.json')) {
       const store = await FileReferenceStore.fromUrl(source);
-      return { store, path: '' };
+      return { store };
     }
     const [root, path] = source.split('.zarr');
     return { store: new HTTPStore(root + '.zarr'), path };
   }
-  return { store: source, path: '' };
+  return { store: source };
 }
 
 export async function open(source: string | ZarrArray['store']) {


### PR DESCRIPTION
The most recent release of `tifffile` introduces a utility to "dump" a `v0` fsspec reference file description translation of a multiscale ome-tiff to the zarr data model if possible (see https://github.com/cgohlke/tifffile/issues/56 for more details).

This PR introduces an experimental `FileReferenceStore` class which adds support for reading this reference when provided as a `source` query param (allowing a user to view an OME-TIFF _as_ zarr in vizarr). 

Steps to reproduce the reference: 

```bash
$ wget https://viv-demo.storage.googleapis.com/Vanderbilt-Spraggins-Kidney-MxIF.ome.tif
$ pip install tifffile==2021.3.17
$ python -m tifffile.tiff2fsspec ./Vanderbilt-Spraggins-Kidney-MxIF.ome.tif https://viv-demo.storage.googleapis.com
```