### PR TITLE
Add fetchOptions to HTTPStore()

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -156,7 +156,7 @@ export async function createSourceData(config: ImageLayerConfig): Promise<Source
       // No rootAttrs in this group.
       // if url is to a plate/acquisition/ check parent dir for 'plate' zattrs
       const parentUrl = node.store.url.slice(0, node.store.url.lastIndexOf('/'));
-      const parent = await openGroup(new HTTPStore(parentUrl));
+      const parent = await open(parentUrl) as ZarrGroup;
       const parentAttrs = (await parent.attrs.asObject()) as Ome.Attrs;
       if ('plate' in parentAttrs) {
         return loadPlate(config, parent, parentAttrs.plate);

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -2,7 +2,7 @@ import { ZarrPixelSource } from '@hms-dbmi/viv';
 import pMap from 'p-map';
 import { Group as ZarrGroup, HTTPStore, openGroup, ZarrArray } from 'zarr';
 import type { ImageLayerConfig, SourceData } from './state';
-import { join, loadMultiscales, guessTileSize, range, parseMatrix } from './utils';
+import { join, loadMultiscales, open, guessTileSize, range, parseMatrix } from './utils';
 
 export async function loadWell(config: ImageLayerConfig, grp: ZarrGroup, wellAttrs: Ome.Well): Promise<SourceData> {
   // Can filter Well fields by URL query ?acquisition=ID
@@ -27,7 +27,7 @@ export async function loadWell(config: ImageLayerConfig, grp: ZarrGroup, wellAtt
   if (acqIds.length > 1) {
     // Need to get acquisitions metadata from parent Plate
     const plateUrl = grp.store.url.replace(`${row}/${col}`, '');
-    const plate = await openGroup(new HTTPStore(plateUrl));
+    const plate = await open(plateUrl) as ZarrGroup;
     const plateAttrs = (await plate.attrs.asObject()) as { plate: Ome.Plate };
     acquisitions = plateAttrs?.plate?.acquisitions ?? [];
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,7 +24,7 @@ async function normalizeStore(source: string | ZarrArray['store']) {
       const { ReferenceStore } = await import('reference-spec-reader');
       return ReferenceStore.fromJSON(await fetch(source).then((res) => res.json()));
     }
-    return new HTTPStore(source);
+    return new HTTPStore(source, { fetchOptions: { credentials: 'include' } });
   }
   return source;
 }


### PR DESCRIPTION
When logged-in to OMERO with the webclient, I would like vizarr to be able to use my current `omero-web` session to load
json and chunks from OMERO.
This needs the HTTPStore fetchOptions to use `{ credentials: 'include' }`.
Two other locations where `new HTTPStore()` is called (for Plate layouts) now use `utils.open()`, although I've not tested loading Plates from OMERO yet.

I see that `normalizeStore()` can return `ReferenceStore.fromJSON()` - not sure if there's a use-case for needing this there too?

Testing with e.g. https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001237.zarr, I see that this fails with:

```
Cross-Origin Request Blocked: The Same Origin Policy disallows reading the remote resource at 
‘https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001237.zarr/.zgroup’. (Reason: Credential is not supported if the CORS header 
‘Access-Control-Allow-Origin’ is ‘*’)
```

So this clearly needs to be an optional flag.

I wonder about simply specifying this in the query string. e.g. `?credentials=include&source=...`

Thanks