### PR TITLE
Ome zarr v0.3 tweaks

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -121,6 +121,9 @@ export async function createSourceData(config: ImageLayerConfig): Promise<Source
 
   if (node instanceof ZarrGroup) {
     const attrs = (await node.attrs.asObject()) as Ome.Attrs;
+    if ('multiscales' in attrs && attrs.multiscales?.[0]?.axes) {
+      config.axis_labels = attrs.multiscales?.[0]?.axes;
+    }
 
     if ('plate' in attrs) {
       return loadPlate(config, node, attrs.plate);

--- a/src/io.ts
+++ b/src/io.ts
@@ -13,6 +13,7 @@ import type {
 import {
   COLORS,
   CYMRGB,
+  getAxisLabels,
   guessTileSize,
   hexToRGB,
   loadMultiscales,
@@ -23,18 +24,6 @@ import {
   range,
   RGB,
 } from './utils';
-
-function getAxisLabels(arr: ZarrArray, axis_labels?: string[], channel_axis?: number) {
-  if (!axis_labels || axis_labels.length != arr.shape.length) {
-    // default axis_labels are e.g. ['0', '1', 'y', 'x']
-    const nonXYaxisLabels = arr.shape.slice(0, -2).map((d, i) => '' + i);
-    axis_labels = nonXYaxisLabels.concat(['y', 'x']);
-  }
-  if (channel_axis) {
-    axis_labels[channel_axis] = 'c';
-  }
-  return axis_labels as [...string[], 'y', 'x'];
-}
 
 function loadSingleChannel(config: SingleChannelConfig, data: ZarrPixelSource<string[]>[], max: number): SourceData {
   const { color, contrast_limits, visibility, name, colormap = '', opacity = 1 } = config;

--- a/src/io.ts
+++ b/src/io.ts
@@ -14,6 +14,7 @@ import {
   COLORS,
   CYMRGB,
   getAxisLabels,
+  getAxisLabelsFromMultiscales,
   guessTileSize,
   hexToRGB,
   loadMultiscales,
@@ -107,6 +108,7 @@ function loadMultiChannel(config: MultichannelConfig, data: ZarrPixelSource<stri
 export async function createSourceData(config: ImageLayerConfig): Promise<SourceData> {
   const node = await open(config.source);
   let data: ZarrArray[];
+  let axis_labels;
 
   if (node instanceof ZarrGroup) {
     const attrs = (await node.attrs.asObject()) as Ome.Attrs;
@@ -139,11 +141,12 @@ export async function createSourceData(config: ImageLayerConfig): Promise<Source
     }
 
     data = await loadMultiscales(node, attrs.multiscales);
+    axis_labels = getAxisLabelsFromMultiscales(attrs);
   } else {
     data = [node];
   }
 
-  const labels = getAxisLabels(data[0], config.axis_labels);
+  const labels = getAxisLabels(data[0], axis_labels || config.axis_labels);
   const tileSize = guessTileSize(data[0]);
   const loader = data.map((d) => new ZarrPixelSource(d, labels, tileSize));
   const [base] = loader;

--- a/src/io.ts
+++ b/src/io.ts
@@ -157,7 +157,9 @@ export async function createSourceData(config: ImageLayerConfig): Promise<Source
   // Now that we have data, try to figure out how to render initially.
 
   // If explicit channel axis is provided, try to load as multichannel.
-  if ('channel_axis' in config) {
+  if ('channel_axis' in config || labels.includes('c')) {
+    config = config as MultichannelConfig;
+    config.channel_axis = config.channel_axis || labels.indexOf('c');
     return loadMultiChannel(config, loader, max);
   }
 

--- a/src/io.ts
+++ b/src/io.ts
@@ -110,9 +110,6 @@ export async function createSourceData(config: ImageLayerConfig): Promise<Source
 
   if (node instanceof ZarrGroup) {
     const attrs = (await node.attrs.asObject()) as Ome.Attrs;
-    if ('multiscales' in attrs && attrs.multiscales?.[0]?.axes) {
-      config.axis_labels = attrs.multiscales?.[0]?.axes;
-    }
 
     if ('plate' in attrs) {
       return loadPlate(config, node, attrs.plate);

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -195,7 +195,8 @@ export async function loadOmeroMultiscales(
 ): Promise<SourceData> {
   const { name, opacity = 1, colormap = '' } = config;
   const data = await loadMultiscales(grp, attrs.multiscales);
-  const axis_labels = getAxisLabels(data[0], config.axis_labels);
+  const default_axes = ['t', 'c', 'z', 'y', 'x'];   // v0.1 & v0.2
+  const axis_labels = getAxisLabels(data[0], config.axis_labels || default_axes);
   const meta = parseOmeroMeta(attrs.omero, axis_labels);
   const tileSize = guessTileSize(data[0]);
 

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -195,7 +195,7 @@ export async function loadOmeroMultiscales(
 ): Promise<SourceData> {
   const { name, opacity = 1, colormap = '' } = config;
   const data = await loadMultiscales(grp, attrs.multiscales);
-  const default_axes = ['t', 'c', 'z', 'y', 'x'];   // v0.1 & v0.2
+  const default_axes = ['t', 'c', 'z', 'y', 'x']; // v0.1 & v0.2
   const axis_labels = getAxisLabels(data[0], config.axis_labels || default_axes);
   const meta = parseOmeroMeta(attrs.omero, axis_labels);
   const tileSize = guessTileSize(data[0]);
@@ -231,7 +231,7 @@ function parseOmeroMeta({ rdefs, channels, name }: Ome.Omero, axis_labels: strin
     names.push(c.label);
   });
 
-  const defaultSelection = axis_labels.map(label => {
+  const defaultSelection = axis_labels.map((label) => {
     if (label == 't') return t;
     if (label == 'z') return z;
     return 0;

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -2,7 +2,7 @@ import { ZarrPixelSource } from '@hms-dbmi/viv';
 import pMap from 'p-map';
 import { Group as ZarrGroup, HTTPStore, openGroup, ZarrArray } from 'zarr';
 import type { ImageLayerConfig, SourceData } from './state';
-import { join, loadMultiscales, getAxisLabels, guessTileSize, range, parseMatrix } from './utils';
+import { join, loadMultiscales, getAxisLabelsFromMultiscales, guessTileSize, range, parseMatrix } from './utils';
 
 export async function loadWell(config: ImageLayerConfig, grp: ZarrGroup, wellAttrs: Ome.Well): Promise<SourceData> {
   // Can filter Well fields by URL query ?acquisition=ID
@@ -253,10 +253,7 @@ function parseOmeroMeta({ rdefs, channels, name }: Ome.Omero, axis_labels: strin
 }
 
 function getOmeAxisLabels(attrs: Ome.Attrs): [...string[], 'y', 'x'] {
-  let axis_labels;
-  if ('multiscales' in attrs && attrs.multiscales?.[0]?.axes) {
-    axis_labels = attrs.multiscales[0].axes;
-  }
+  let axis_labels = getAxisLabelsFromMultiscales(attrs);
   const default_axes = ['t', 'c', 'z', 'y', 'x']; // v0.1 & v0.2
   return (axis_labels || default_axes) as [...string[], 'y', 'x'];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,13 +89,13 @@ export function join(...args: (string | undefined)[]) {
     .join('/');
 }
 
-export function getAxisLabels(arr: ZarrArray, axis_labels?: string[]): string[] {
+export function getAxisLabels(arr: ZarrArray, axis_labels?: string[]): [...string[], 'y', 'x'] {
   if (!axis_labels || axis_labels.length != arr.shape.length) {
     // default axis_labels are e.g. ['0', '1', 'y', 'x']
     const nonXYaxisLabels = arr.shape.slice(0, -2).map((_, i) => '' + i);
     axis_labels = nonXYaxisLabels.concat(['y', 'x']);
   }
-  return axis_labels;
+  return axis_labels as [...string[], 'y', 'x'];
 }
 
 export function isInterleaved(shape: number[]) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -100,12 +100,6 @@ export function getAxisLabels(arr: ZarrArray, axis_labels?: string[]): [...strin
   return axis_labels as [...string[], 'y', 'x'];
 }
 
-export function getAxisLabelsFromMultiscales(attrs) {
-  if ('multiscales' in attrs && attrs.multiscales?.[0]?.axes) {
-    return attrs.multiscales[0].axes;
-  }
-}
-
 export function isInterleaved(shape: number[]) {
   const lastDimSize = shape[shape.length - 1];
   return lastDimSize === 3 || lastDimSize === 4;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,7 +38,7 @@ async function normalizeStore(source: string | Store) {
     // Wrap remote stores in a cache
     // see https://github.com/hms-dbmi/vizarr/pull/100#issuecomment-893493514
     // return new LRUCacheStore(store);
-    return store
+    return store;
   }
 
   return source;
@@ -98,6 +98,12 @@ export function getAxisLabels(arr: ZarrArray, axis_labels?: string[]): [...strin
     axis_labels = nonXYaxisLabels.concat(['y', 'x']);
   }
   return axis_labels as [...string[], 'y', 'x'];
+}
+
+export function getAxisLabelsFromMultiscales(attrs) {
+  if ('multiscales' in attrs && attrs.multiscales?.[0]?.axes) {
+    return attrs.multiscales[0].axes;
+  }
 }
 
 export function isInterleaved(shape: number[]) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import { ContainsArrayError, HTTPStore, openArray, openGroup, ZarrArray } from '
 import type { Group as ZarrGroup } from 'zarr';
 import type { AsyncStore, Store } from 'zarr/types/storage/types';
 import { Matrix4 } from '@math.gl/core/dist/esm';
-import { LRUCacheStore } from './lru-store';
+// import { LRUCacheStore } from './lru-store';
 
 export const MAX_CHANNELS = 6;
 
@@ -36,7 +36,9 @@ async function normalizeStore(source: string | Store) {
     }
 
     // Wrap remote stores in a cache
-    return new LRUCacheStore(store);
+    // see https://github.com/hms-dbmi/vizarr/pull/100#issuecomment-893493514
+    // return new LRUCacheStore(store);
+    return store
   }
 
   return source;

--- a/types/ome.ts
+++ b/types/ome.ts
@@ -31,6 +31,7 @@ declare module Ome {
   interface Multiscale {
     datasets: { path: string }[];
     version?: string;
+    axes?: string[];
   }
 
   interface Acquisition {


### PR DESCRIPTION
See #103 

Use the `axes` data for dimension names and don't assume data is 5D.

This PR build is deployed at https://deploy-preview-104--vizarr.netlify.app/
These currently all working except 2D example:

 - 2D (YX): https://deploy-preview-104--vizarr.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.3/idr0094-ellinger-sarscov2/10503791.zarr
 - 3D (CXY): https://deploy-preview-104--vizarr.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.3/idr0077-valuchova-flowerlightsheet/9836842.zarr
 - 4D (TCYX) https://deploy-preview-104--vizarr.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.3/idr0002-heriche-condensation/179758.zarr
 - 4D (CZYX): https://deploy-preview-104--vizarr.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.3/idr0062-blin-nuclearsegmentation/6001240.zarr
 - 4D (TCYX): https://deploy-preview-104--vizarr.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.3/idr0077-valuchova-flowerlightsheet/9836849.zarr
