### PR TITLE
bump zarr with support for dimension_separator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -377,6 +377,17 @@
         "math.gl": "^3.3.0",
         "quickselect": "^2.0.0",
         "zarr": "^0.4.0"
+      },
+      "dependencies": {
+        "zarr": {
+          "version": "0.4.2",
+          "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.4.2.tgz",
+          "integrity": "sha512-zyC1DaVURXqSEP6O0R8XOYa83RZkCpEHLUFOCsYn1a5n1j6ojwzwoUgeMOtHuNfuJwUnb8dGK0g3gTGGs87QiQ==",
+          "requires": {
+            "numcodecs": "^0.2.0",
+            "p-queue": "6.2.0"
+          }
+        }
       }
     },
     "@loaders.gl/3d-tiles": {
@@ -2502,12 +2513,9 @@
       "dev": true
     },
     "numcodecs": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.1.1.tgz",
-      "integrity": "sha512-UjKulZ6GIFKLdBIczEbsoXNZQmiHafpoIdo39YcdecHVGyMKh0+azsfHTrybXm5RZwepqLZv24mkjqGdZGm24Q==",
-      "requires": {
-        "pako": "^1.0.11"
-      }
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.1.tgz",
+      "integrity": "sha512-0ktyCFBEno8mLuC/bTfJk8LjDy7GvQOa9Ern2zsAhM8sU5uiUGZPyXVzD7kEtx90fRPzohodg1fd82/xzAupLA=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -3281,11 +3289,11 @@
       "dev": true
     },
     "zarr": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.4.0.tgz",
-      "integrity": "sha512-zvxdX3aRWxjy6H3OtA7R05NNZvRKxn/7bkNJhUsVKKbNoJ3DBqYERQfzI4WfAV1OTcclqvlYwkQ7DWsGJA5QEw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.5.0.tgz",
+      "integrity": "sha512-8A6nV4VR6Y927lUuTwtj6Qd4MwWGBxBVcS7mnZMkYJGPjXv48SOiGr5lC0xIWp6GtX+tQMCgzEloT5rwUsv0Dw==",
       "requires": {
-        "numcodecs": "^0.1.0",
+        "numcodecs": "^0.2.0",
         "p-queue": "6.2.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "reference-spec-reader": "^0.1.1",
-    "zarr": "^0.4.0"
+    "zarr": "^0.5.0"
   },
   "scripts": {
     "start": "snowpack dev",

--- a/src/io.ts
+++ b/src/io.ts
@@ -18,7 +18,6 @@ import {
   loadMultiscales,
   MAGENTA_GREEN,
   MAX_CHANNELS,
-  nested,
   open,
   parseMatrix,
   range,
@@ -116,29 +115,12 @@ function loadMultiChannel(config: MultichannelConfig, data: ZarrPixelSource<stri
   };
 }
 
-function isNested(attrs: Ome.Attrs) {
-  let version;
-  if ('plate' in attrs) {
-    version = attrs.plate.version;
-  } else if ('omero' in attrs) {
-    version = attrs.multiscales[0].version;
-  } else if ('well' in attrs) {
-    version = attrs.well.version;
-  }
-  // OME-Zarr uses nested chunks since version 0.2
-  return version && version !== '0.1';
-}
-
 export async function createSourceData(config: ImageLayerConfig): Promise<SourceData> {
   const node = await open(config.source);
   let data: ZarrArray[];
 
   if (node instanceof ZarrGroup) {
     const attrs = (await node.attrs.asObject()) as Ome.Attrs;
-
-    if (isNested(attrs)) {
-      node.store = nested(node.store);
-    }
 
     if ('plate' in attrs) {
       return loadPlate(config, node, attrs.plate);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,24 +61,6 @@ export async function loadMultiscales(grp: ZarrGroup, multiscales: Ome.Multiscal
   throw Error('Multiscales metadata included a path to a group.');
 }
 
-export function nested(store: ZarrArray['store']) {
-  const get = (target: ZarrArray['store'], key: string | number | symbol) => {
-    if (key === 'getItem' || key === 'containsItem') {
-      return (path: string, ...args: unknown[]) => {
-        if (path.endsWith('.zarray') || path.endsWith('.zattrs') || path.endsWith('.zgroup')) {
-          return target[key](path, ...args);
-        }
-        const prefix = path.split('/');
-        const chunkKey = prefix.pop()!;
-        const newPath = [...prefix, chunkKey.replaceAll('.', '/')].join('/');
-        return target[key](newPath, ...args);
-      };
-    }
-    return Reflect.get(target, key);
-  };
-  return new Proxy(store, { get });
-}
-
 export function hexToRGB(hex: string): number[] {
   if (hex.startsWith('#')) hex = hex.slice(1);
   const r = parseInt(hex.slice(0, 2), 16);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,9 @@
     "jsx": "preserve",
     "baseUrl": "./",
     /* paths - If you configure Snowpack import aliases, add them here. */
-    "paths": {},
+    "paths": {
+      "zarr": ["node_modules/zarr"]
+    },
     /* noEmit - Snowpack builds (emits) files, not tsc. */
     "noEmit": true,
     /* Additional Options */


### PR DESCRIPTION
@will-moore @joshmoore 

Zarr.js now has support for `dimension_separator`, so the store should no long need to modify chunk keys. It would be my preference that we rely on zarr rather than inspecting the ome metadata to determine how to initialize a custom store. 

It is my impression that datasets coming from the IDR (or generated with bioformats2raw) will include `dimension_separator` in the array metadata. 