### PR TITLE
Replace custom plugin with @rollup/plugin-virtual

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -810,6 +810,12 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "@rollup/plugin-virtual": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-virtual/-/plugin-virtual-2.0.3.tgz",
+      "integrity": "sha512-pw6ziJcyjZtntQ//bkad9qXaBx665SgEL8C8KI5wO8G5iU5MPxvdWrQyVaAvjojGm9tJoS8M9Z/EEepbqieYmw==",
+      "dev": true
+    },
     "@snowpack/plugin-react-refresh": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@snowpack/plugin-react-refresh/-/plugin-react-refresh-2.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@danmarshall/deckgl-typings": "^4.3.10",
+    "@rollup/plugin-virtual": "^2.0.3",
     "@snowpack/plugin-react-refresh": "^2.3.7",
     "@snowpack/plugin-typescript": "^1.1.0",
     "@types/node": "^14.14.5",

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -1,4 +1,10 @@
 const pkg = require('./package.json');
+const virtual = require('@rollup/plugin-virtual');
+
+const geotiff = `\
+export const fromBlob = '';
+export const fromUrl = '';
+`;
 
 // pkg version avaiable in app via import.meta.env.SNOWPACK_PUBLIC_PACKAGE_VERSION
 process.env.SNOWPACK_PUBLIC_PACKAGE_VERSION = pkg.version;
@@ -15,7 +21,7 @@ module.exports = {
   ],
   packageOptions: {
     rollup: {
-      plugins: [ resolveGeotiff() ],
+      plugins: [ virtual({ geotiff }) ],
     },
   },
   devOptions: {
@@ -30,25 +36,3 @@ module.exports = {
     /* ... */
   },
 };
-
-
-/* 
-* Custom Rollup Plugin for installing geotiff.js
-*
-* vizarr doesn't use geotiff component of viv.
-* This plugin just creates an empty shim for 
-* top-level imports in viv during install by snowpack.
-*/
-
-function resolveGeotiff() {
-  return {
-    name: 'resolve-empty-geotiff',
-    async load(id) {
-      if (!id.includes('geotiff.js')) return;
-      return `
-      export const fromBlob = '';
-      export const fromUrl = '';
-      `;
-    },
-  }
-}


### PR DESCRIPTION
Replace the behavior of custom rollup plugin with official `@rollup/plugin-virtual`.