### PR TITLE
Remove key from cache if promise errors out

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "start": "snowpack dev",
     "build": "snowpack build",
     "export": "npm run build",
-    "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx}\"",
-    "lint": "prettier --check \"src/**/*.{js,jsx,ts,tsx}\"",
+    "format": "prettier --write \"{src,types}/**/*.{js,jsx,ts,tsx}\" snowpack.config.js",
+    "lint": "prettier --check \"{src,types}/**/*.{js,jsx,ts,tsx}\" snowpack.config.js",
     "prepublishOnly": "npm run build && cp -r ./out/* .",
     "postpublish": "git clean -fd"
   },

--- a/snowpack.config.js
+++ b/snowpack.config.js
@@ -9,13 +9,10 @@ module.exports = {
     public: '/',
     src: '/_dist_',
   },
-  plugins: [
-    '@snowpack/plugin-react-refresh',
-    '@snowpack/plugin-typescript',
-  ],
+  plugins: ['@snowpack/plugin-react-refresh', '@snowpack/plugin-typescript'],
   packageOptions: {
     rollup: {
-      plugins: [ resolveGeotiff() ],
+      plugins: [resolveGeotiff()],
     },
   },
   devOptions: {
@@ -31,14 +28,13 @@ module.exports = {
   },
 };
 
-
-/* 
-* Custom Rollup Plugin for installing geotiff.js
-*
-* vizarr doesn't use geotiff component of viv.
-* This plugin just creates an empty shim for 
-* top-level imports in viv during install by snowpack.
-*/
+/*
+ * Custom Rollup Plugin for installing geotiff.js
+ *
+ * vizarr doesn't use geotiff component of viv.
+ * This plugin just creates an empty shim for
+ * top-level imports in viv during install by snowpack.
+ */
 
 function resolveGeotiff() {
   return {
@@ -50,5 +46,5 @@ function resolveGeotiff() {
       export const fromUrl = '';
       `;
     },
-  }
+  };
 }

--- a/src/lru-store.ts
+++ b/src/lru-store.ts
@@ -2,9 +2,9 @@ import type { AsyncStore } from 'zarr/types/storage/types';
 import QuickLRU from 'quick-lru';
 
 export class LRUCacheStore<S extends AsyncStore<ArrayBuffer>> {
-  private cache: QuickLRU<string, Promise<ArrayBuffer>>;
+  cache: QuickLRU<string, Promise<ArrayBuffer>>;
 
-  constructor(public store: S, public maxSize: number = 100) {
+  constructor(public store: S, maxSize: number = 100) {
     this.cache = new QuickLRU({ maxSize });
   }
 
@@ -13,7 +13,7 @@ export class LRUCacheStore<S extends AsyncStore<ArrayBuffer>> {
     if (this.cache.has(key)) {
       return this.cache.get(key)!;
     }
-    const value = this.store.getItem(key, opts).catch(err => {
+    const value = this.store.getItem(key, opts).catch((err) => {
       this.cache.delete(key);
       throw err;
     });
@@ -25,8 +25,8 @@ export class LRUCacheStore<S extends AsyncStore<ArrayBuffer>> {
     return this.cache.has(key) || this.store.containsItem(key);
   }
 
-  async keys() {
-    return [];
+  keys() {
+    return this.store.keys();
   }
 
   deleteItem(key: string): never {

--- a/src/lru-store.ts
+++ b/src/lru-store.ts
@@ -13,7 +13,10 @@ export class LRUCacheStore<S extends AsyncStore<ArrayBuffer>> {
     if (this.cache.has(key)) {
       return this.cache.get(key)!;
     }
-    const value = this.store.getItem(key, opts);
+    const value = this.store.getItem(key, opts).catch(err => {
+      this.cache.delete(key);
+      throw err;
+    });
     this.cache.set(key, value);
     return value;
   }

--- a/types/ome.ts
+++ b/types/ome.ts
@@ -3,7 +3,7 @@ declare module Ome {
 
   interface Channel {
     active: boolean;
-    coefficient: number, 
+    coefficient: number;
     color: string;
     family: string;
     inverted: boolean;
@@ -46,7 +46,7 @@ declare module Ome {
   }
 
   interface Plate {
-    acquisitions?: Acquisition[]; 
+    acquisitions?: Acquisition[];
     columns: { name: string }[];
     field_count: 4;
     name: string;
@@ -56,13 +56,13 @@ declare module Ome {
   }
 
   interface Well {
-    images: { path: string, acquisition?: number }[];
+    images: { path: string; acquisition?: number }[];
     version: Version;
   }
 
   type Attrs =
-    { multiscales: Multiscale[] } |
-    { omero: Omero, multiscales: Multiscale[] } |
-    { plate: Plate } |
-    { well: Well };
+    | { multiscales: Multiscale[] }
+    | { omero: Omero; multiscales: Multiscale[] }
+    | { plate: Plate }
+    | { well: Well };
 }

--- a/types/viv.d.ts
+++ b/types/viv.d.ts
@@ -11,5 +11,5 @@ declare module 'viv-layers' {
     channelIsOn: boolean[];
     colormap: null | string;
     modelMatrix: Matrix4;
-  };
+  }
 }


### PR DESCRIPTION
Improves #107. Now that the cache stores promises, we want to remove the key from the cache if the promise rejects.  