### PR TITLE
Load each Well to get path to first image for each

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -54,6 +54,14 @@ export async function open(source: string | Store) {
   });
 }
 
+const decoder = new TextDecoder();
+export function getAttrsOnly<T = unknown>(grp: ZarrGroup, path: string) {
+  return (grp.store as AsyncStore<ArrayBuffer>)
+    .getItem(join(grp.path, path, ".zattrs"))
+    .then((b) => decoder.decode(b))
+    .then((text) => JSON.parse(text) as T);
+}
+
 export async function loadMultiscales(grp: ZarrGroup, multiscales: Ome.Multiscale[]) {
   const { datasets } = multiscales[0] || [{ path: '0' }];
   const nodes = await Promise.all(datasets.map(({ path }) => grp.getItem(path)));


### PR DESCRIPTION
Fixes #118.

Instead of just using the first Well of a plate to get the path from Well -> Image, this PR loads every Well to handle the case when each Well has a different path to Image.

However, this makes 3 extra calls for each Well e.g. `A/1/.zattrs` (loads the data we need), `A/1/.zgroup` (not needed) and `A/1/.zarray` (404). So maybe there's a better way to load the `.zattrs` for each Well @manzt ?

This will have performance implications for loading Plates, especially large plates, so shouldn't be merged unless we're happy with that.

cc @joshmoore
cc @camFoltz