### PR TITLE
Polygon display

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -122,3 +122,10 @@ export const layerAtoms = atom((get) => {
   const layers = atoms.map((a) => layerFamilyAtom(get(a)));
   return get(waitForAll(layers));
 });
+
+export type PolyGon = {
+  path: number[][];
+  strokeColor: number[];
+};
+
+export const polygonsAtom = atom<PolyGon[]>([]);

--- a/src/vizarr.tsx
+++ b/src/vizarr.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect } from 'react';
 import { useUpdateAtom } from 'jotai/utils';
 
-import { sourceInfoAtom, viewStateAtom } from './state';
+import { sourceInfoAtom, viewStateAtom, polygonsAtom } from './state';
 import type { ImageLayerConfig } from './state';
+import { parsePolygons } from './utils';
 
 import Viewer from './components/Viewer';
 import Menu from './components/Menu';
@@ -12,6 +13,7 @@ import { version } from '../package.json';
 function App() {
   const setSourceInfo = useUpdateAtom(sourceInfoAtom);
   const setViewState = useUpdateAtom(viewStateAtom);
+  const setPolygons = useUpdateAtom(polygonsAtom);
 
   async function addImage(config: ImageLayerConfig) {
     const { createSourceData } = await import('./io');
@@ -32,6 +34,10 @@ function App() {
       const config = {} as any;
       for (const [key, value] of params) {
         config[key] = value;
+      }
+      const polygons = parsePolygons(config.polygons, config.strokeColor);
+      if (polygons) {
+        setPolygons(polygons);
       }
       // Make sure the source URL is decoded.
       config.source = decodeURIComponent(config.source);


### PR DESCRIPTION
See #127

Since this is a feature I expect to be of use to OME and others, I started to look at supporting viewing Polygons in vizarr.

Initially this uses query params e.g. `?polygons=[[[100,100],[100,200],[110,180],[200,250]],[[10,0],[50,120],[75,0]]]&strokeColor=ff0000` in the screenshot below or try: https://deploy-preview-128--vizarr.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.3/datasets/idr0062/8dc4707/7754.zarr/B1_C1.tif/&polygons=[[[100,100],[100,200],[110,180],[200,250]],[[10,0],[50,120],[75,0]]]&strokeColor=ff0000

That has the obvious limitation of all Polygons being the same colour and same line width. Fill Colour isn't supported either.

![Screenshot 2021-11-03 at 18 07 08](https://user-images.githubusercontent.com/900055/140167538-ae21ada4-c9da-42cf-ab0d-6b41eeee124a.png)

I'll look at adding methods to the notebook API...
