### PR TITLE
feat: add jpeg2k codec

### DIFF
--- a/example/mandelbrot.ipynb
+++ b/example/mandelbrot.ipynb
@@ -142,13 +142,12 @@
     "        from_x, from_y, to_x, to_y = tile_bounds(level, x, y, self.levels)\n",
     "        out = np.zeros(self.tilesize * self.tilesize, dtype=self.dtype)\n",
     "        tile = mandelbrot(out, from_x, from_y, to_x, to_y, self.tilesize, self.maxiter)\n",
-    "\n",
-    "        dbytes = tile.tobytes()\n",
+    "        tile = tile.reshape(self.tilesize, self.tilesize)\n",
     "\n",
     "        if self.compressor:\n",
-    "            return self.compressor.encode(dbytes)\n",
+    "            return self.compressor.encode(tile)\n",
     "\n",
-    "        return dbytes\n",
+    "        return tile.tobytes()\n",
     "\n",
     "    def keys(self):\n",
     "        return self._store.keys()\n",
@@ -199,7 +198,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -213,7 +212,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.9.6"
   }
  },
  "nbformat": 4,

--- a/src/codecs/jpeg2k.ts
+++ b/src/codecs/jpeg2k.ts
@@ -1,0 +1,23 @@
+// TODO: Remove dependency on CDN for pdf.js source. Could use git submodule or
+// `deno bundle` since the pdf.js dist does not include ESM source code (only UMD or CJS).
+
+// @ts-ignore
+import { JpxImage } from 'https://cdn.jsdelivr.net/gh/mozilla/pdf.js/src/core/jpx.js';
+
+export default class Jpeg2k {
+  static codecId: 'jpeg2k';
+  static fromConfig(_: Record<string, any>): Jpeg2k {
+    return new Jpeg2k();
+  }
+
+  encode(_: Uint8Array): never {
+    throw new Error('encode not implemented');
+  }
+
+  async decode(data: Uint8Array): Promise<Uint8Array> {
+    const img = new JpxImage();
+    img.failOnCorruptedImage = true;
+    img.parse(data);
+    return img.tiles[0].items;
+  }
+}

--- a/src/codecs/register.ts
+++ b/src/codecs/register.ts
@@ -28,3 +28,4 @@ add('gzip', () => import('numcodecs/gzip'));
 add('zlib', () => import('numcodecs/zlib'));
 add('zstd', () => import('numcodecs/zstd'));
 add('blosc', () => import('numcodecs/blosc'));
+add('jpeg2k', () => import('./jpeg2k'));

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,7 +5,7 @@ import { ThemeProvider } from '@material-ui/styles';
 
 import Vizarr from './vizarr';
 import theme from './theme';
-import './register-codecs';
+import './codecs/register';
 
 import { version } from '../package.json';
 


### PR DESCRIPTION
Supports jpeg2k codec from https://github.com/glencoesoftware/zarr-jpeg2k. You can try it out in the `examples/mandelbrot.ipynb`:

```python
from imjoy_plugin import run_vizarr
from zarr_jpeg2k import jpeg2k
import zarr

store = MandlebrotStore(levels=50, tilesize=512, compressor=jpeg2k(level=10)) # add codec
store = zarr.LRUStoreCache(store, max_size=1e9)
z_grp = zarr.open(store, mode="r")

img = { "source": z_grp, "name": "mandelbrot" }

run_vizarr(img)
```

Be sure to change the `url` in `examples/imjoy_plugin.py` to `http://localhost:3000` when running the vite dev server.