### PR TITLE
feat: open vizarrr with default view (in dev)

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script type="module" src="/src/index.tsx"></script>
     <style>
-      @import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap');
       html {
         background-color: black;
       }

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,5 +18,5 @@ export default defineConfig({
       geotiff: resolve(__dirname, 'src/empty:geotiff.js'),
     },
   },
-  server: { open: `?source=${source}` }
+  server: { open: `?source=${source}` },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,8 @@ import react from '@vitejs/plugin-react';
 
 import { resolve } from 'path';
 
+const source = process.env.VIZARR_DATA || 'https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001253.zarr';
+
 export default defineConfig({
   plugins: [react()],
   base: process.env.VIZARR_PREFIX || './',
@@ -16,4 +18,5 @@ export default defineConfig({
       geotiff: resolve(__dirname, 'src/empty:geotiff.js'),
     },
   },
+  server: { open: `?source=${source}` }
 });


### PR DESCRIPTION
There is no default dataset when the dev server starts -- `npm start` (`vite`). The PR adds a default `open` url to launch in the browser. It also adds a `VIZARR_DATA` environment variable to change this dataset.

Usage:

```
npm start # opens http://localhost:3000/?source=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/6001253.zarr
VIZARR_DATA=https://s3.embassy.ebi.ac.uk/idr/zarr/v0.1/9836831.zarr npm start
```

