### PR TITLE
Handle Plate and Well with no 'omero' metadata

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -12,17 +12,15 @@ import type {
 } from './state';
 import {
   COLORS,
-  CYMRGB,
+  getDefaultColors,
+  getDefaultVisibilities,
   getAxisLabels,
   guessTileSize,
   hexToRGB,
   loadMultiscales,
-  MAGENTA_GREEN,
-  MAX_CHANNELS,
   open,
   parseMatrix,
   range,
-  RGB,
 } from './utils';
 
 function loadSingleChannel(config: SingleChannelConfig, data: ZarrPixelSource<string[]>[], max: number): SourceData {
@@ -56,36 +54,9 @@ function loadMultiChannel(config: MultichannelConfig, data: ZarrPixelSource<stri
     }
   }
 
-  if (!visibilities) {
-    if (n <= MAX_CHANNELS) {
-      // Default to all on if visibilities not specified and less than 6 channels.
-      visibilities = Array(n).fill(true);
-    } else {
-      // If more than MAX_CHANNELS, only make first set on by default.
-      visibilities = [...Array(MAX_CHANNELS).fill(true), ...Array(n - MAX_CHANNELS).fill(false)];
-    }
-  }
+  visibilities = visibilities || getDefaultVisibilities(n);
+  colors = colors || getDefaultColors(n, visibilities);
 
-  if (!colors) {
-    if (n == 1) {
-      colors = [COLORS.white];
-    } else if (n == 2) {
-      colors = MAGENTA_GREEN;
-    } else if (n === 3) {
-      colors = RGB;
-    } else if (n <= MAX_CHANNELS) {
-      colors = CYMRGB.slice(0, n);
-    } else {
-      // Default color for non-visible is white
-      colors = Array(n).fill(COLORS.white);
-      // Get visible indices
-      const visibleIndices = visibilities.flatMap((bool, i) => (bool ? i : []));
-      // Set visible indices to CYMRGB colors. visibleIndices.length === MAX_CHANNELS from above.
-      for (const [i, visibleIndex] of visibleIndices.entries()) {
-        colors[visibleIndex] = CYMRGB[i];
-      }
-    }
-  }
   return {
     loader: data,
     name,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -109,6 +109,42 @@ export function getAxisLabels(arr: ZarrArray, axis_labels?: string[]): [...strin
   return axis_labels as [...string[], 'y', 'x'];
 }
 
+export function getDefaultVisibilities(n: number, visibilities?: boolean[]): boolean[] {
+  if (!visibilities) {
+    if (n <= MAX_CHANNELS) {
+      // Default to all on if visibilities not specified and less than 6 channels.
+      visibilities = Array(n).fill(true);
+    } else {
+      // If more than MAX_CHANNELS, only make first set on by default.
+      visibilities = [...Array(MAX_CHANNELS).fill(true), ...Array(n - MAX_CHANNELS).fill(false)];
+    }
+  }
+  return visibilities;
+}
+
+export function getDefaultColors(n: number, visibilities: boolean[]): string[] {
+  let colors = [];
+  if (n == 1) {
+    colors = [COLORS.white];
+  } else if (n == 2) {
+    colors = MAGENTA_GREEN;
+  } else if (n === 3) {
+    colors = RGB;
+  } else if (n <= MAX_CHANNELS) {
+    colors = CYMRGB.slice(0, n);
+  } else {
+    // Default color for non-visible is white
+    colors = Array(n).fill(COLORS.white);
+    // Get visible indices
+    const visibleIndices = visibilities.flatMap((bool, i) => (bool ? i : []));
+    // Set visible indices to CYMRGB colors. visibleIndices.length === MAX_CHANNELS from above.
+    for (const [i, visibleIndex] of visibleIndices.entries()) {
+      colors[visibleIndex] = CYMRGB[i];
+    }
+  }
+  return colors;
+}
+
 export function isInterleaved(shape: number[]) {
   const lastDimSize = shape[shape.length - 1];
   return lastDimSize === 3 || lastDimSize === 4;


### PR DESCRIPTION
As noticed by @sbesson, OME-NGFF Plates and Wells without the optional `omero` rendering settings fail to open in vizarr.

This uses the defaults behaviour for other images without rendering settings.
To test, try sample data at:

Plate: https://uk1s3.embassy.ebi.ac.uk/ngff_sparse_hcs/9477_bf2raw_0_3_0.zarr
Well: click on one of the Wells above.

NB: because the rendering settings default range is the max range of the pixel type, you need to boost the levels a lot before you can see anything:

![Screenshot 2021-11-30 at 12 06 06](https://user-images.githubusercontent.com/900055/144044383-6d0a599f-ccca-4dfe-b215-51fe3c254903.png)

TODO: when a single Image from that Plate is viewed, it is not recognised as a multi-channel Image:
https://uk1s3.embassy.ebi.ac.uk/ngff_sparse_hcs/9477_bf2raw_0_3_0.zarr/0/11/0