### PR TITLE
feat(viewer): dynamic contrast limits

### DIFF
--- a/src/components/LayerController/AddChannelButton.tsx
+++ b/src/components/LayerController/AddChannelButton.tsx
@@ -42,6 +42,7 @@ function AddChannelButton({ sourceAtom, layerAtom }: ControllerProps) {
       const { loader } = layer.layerProps;
       const lowres = Array.isArray(loader) ? loader[loader.length - 1] : loader;
       lim = await calcDataRange(lowres, channelSelection);
+      // Update source data with newly calculated limit
       setSourceData((prev) => {
         const clims = [...prev.contrast_limits];
         clims[channelIndex] = lim;
@@ -53,7 +54,7 @@ function AddChannelButton({ sourceAtom, layerAtom }: ControllerProps) {
       const { layerProps } = prev;
       const loaderSelection = [...layerProps.loaderSelection, channelSelection];
       const colorValues = [...layerProps.colorValues, hexToRGB(colors[channelIndex])];
-      const sliderValues = [...layerProps.sliderValues, lim as number[]];
+      const sliderValues = [...layerProps.sliderValues, lim];
       const contrastLimits = [...sliderValues];
       const channelIsOn = [...layerProps.channelIsOn, true];
       return {

--- a/src/components/LayerController/AddChannelButton.tsx
+++ b/src/components/LayerController/AddChannelButton.tsx
@@ -1,15 +1,14 @@
 import React, { useState } from 'react';
 import type { MouseEvent, ChangeEvent } from 'react';
 import { useAtom } from 'jotai';
-import { useAtomValue } from 'jotai/utils';
 import { IconButton, Popover, Paper, Typography, Divider, NativeSelect } from '@material-ui/core';
 import { Add } from '@material-ui/icons';
 
-import { hexToRGB, MAX_CHANNELS } from '../../utils';
+import { calcDataRange, hexToRGB, MAX_CHANNELS } from '../../utils';
 import type { ControllerProps } from '../../state';
 
 function AddChannelButton({ sourceAtom, layerAtom }: ControllerProps) {
-  const sourceData = useAtomValue(sourceAtom);
+  const [sourceData, setSourceData] = useAtom(sourceAtom);
   const [layer, setLayer] = useAtom(layerAtom);
   const [anchorEl, setAnchorEl] = useState<null | Element>(null);
 
@@ -21,7 +20,7 @@ function AddChannelButton({ sourceAtom, layerAtom }: ControllerProps) {
     setAnchorEl(null);
   };
 
-  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+  const handleChange = async (event: ChangeEvent<HTMLSelectElement>) => {
     const {
       defaults: { selection },
       channel_axis,
@@ -34,11 +33,27 @@ function AddChannelButton({ sourceAtom, layerAtom }: ControllerProps) {
     if (channel_axis) {
       channelSelection[channel_axis] = channelIndex;
     }
+
+    // cacluate contrast limits if missing from source;
+    let lim: number[];
+    if (contrast_limits[channelIndex]) {
+      lim = contrast_limits[channelIndex] as number[];
+    } else {
+      const { loader } = layer.layerProps;
+      const lowres = Array.isArray(loader) ? loader[loader.length - 1] : loader;
+      lim = await calcDataRange(lowres, channelSelection);
+      setSourceData((prev) => {
+        const clims = [...prev.contrast_limits];
+        clims[channelIndex] = lim;
+        return { ...prev, contrast_limits: clims };
+      });
+    }
+
     setLayer((prev) => {
       const { layerProps } = prev;
       const loaderSelection = [...layerProps.loaderSelection, channelSelection];
       const colorValues = [...layerProps.colorValues, hexToRGB(colors[channelIndex])];
-      const sliderValues = [...layerProps.sliderValues, contrast_limits[channelIndex]];
+      const sliderValues = [...layerProps.sliderValues, lim as number[]];
       const contrastLimits = [...sliderValues];
       const channelIsOn = [...layerProps.channelIsOn, true];
       return {

--- a/src/io.ts
+++ b/src/io.ts
@@ -63,7 +63,9 @@ async function loadMultiChannel(
 
   visibilities = visibilities || getDefaultVisibilities(n);
   colors = colors || getDefaultColors(n, visibilities);
-  const contrastLimits = contrast_limits ?? (await (() => calcConstrastLimits(data[data.length - 1], channelAxis))());
+
+  const contrastLimits =
+    contrast_limits ?? (await (() => calcConstrastLimits(data[data.length - 1], channelAxis, visibilities))());
 
   return {
     loader: data,
@@ -170,15 +172,14 @@ export function initLayerStateFromSource(sourceData: SourceData): LayerState {
 
   const visibleIndices = visibilities.flatMap((bool, i) => (bool ? i : []));
   for (const index of visibleIndices) {
+    const channelSelection = [...selection];
     if (Number.isInteger(channel_axis)) {
-      const channelSelection = [...selection];
       channelSelection[channel_axis as number] = index;
-      loaderSelection.push(channelSelection);
-    } else {
-      loaderSelection.push(selection);
     }
+    loaderSelection.push(channelSelection);
     colorValues.push(hexToRGB(colors[index]));
-    contrastLimits.push(contrast_limits[index]);
+    // TODO: should never be undefined
+    contrastLimits.push(contrast_limits[index] ?? [0, 255]);
     channelIsOn.push(true);
   }
   // set initial slider values to contrast_limits

--- a/src/io.ts
+++ b/src/io.ts
@@ -1,4 +1,4 @@
-import { DTYPE_VALUES, ImageLayer, MultiscaleImageLayer, ZarrPixelSource } from '@hms-dbmi/viv';
+import { ImageLayer, MultiscaleImageLayer, ZarrPixelSource } from '@hms-dbmi/viv';
 import { Group as ZarrGroup, openGroup, ZarrArray } from 'zarr';
 import GridLayer from './gridLayer';
 import { loadOmeroMultiscales, loadPlate, loadWell } from './ome';
@@ -21,17 +21,20 @@ import {
   open,
   parseMatrix,
   range,
+  calcDataRange,
+  calcConstrastLimits,
 } from './utils';
 
-function loadSingleChannel(config: SingleChannelConfig, data: ZarrPixelSource<string[]>[], max: number): SourceData {
+async function loadSingleChannel(config: SingleChannelConfig, data: ZarrPixelSource<string[]>[]): Promise<SourceData> {
   const { color, contrast_limits, visibility, name, colormap = '', opacity = 1 } = config;
+  const limits = contrast_limits ?? (await (() => calcDataRange(data[data.length - 1], [0, 0, 0]))());
   return {
     loader: data,
     name,
     channel_axis: null,
     colors: [color ?? COLORS.white],
     names: ['channel_0'],
-    contrast_limits: [contrast_limits ?? [0, max]],
+    contrast_limits: [limits],
     visibilities: [visibility ?? true],
     model_matrix: parseMatrix(config.model_matrix),
     defaults: {
@@ -43,10 +46,14 @@ function loadSingleChannel(config: SingleChannelConfig, data: ZarrPixelSource<st
   };
 }
 
-function loadMultiChannel(config: MultichannelConfig, data: ZarrPixelSource<string[]>[], max: number): SourceData {
-  const { names, channel_axis, name, model_matrix, opacity = 1, colormap = '' } = config;
-  let { contrast_limits, visibilities, colors } = config;
-  const n = data[0].shape[channel_axis as number];
+async function loadMultiChannel(
+  config: MultichannelConfig,
+  data: ZarrPixelSource<string[]>[],
+  channelAxis: number
+): Promise<SourceData> {
+  const { names, contrast_limits, name, model_matrix, opacity = 1, colormap = '' } = config;
+  let { visibilities, colors } = config;
+  const n = data[0].shape[channelAxis];
   for (const channelProp of [contrast_limits, visibilities, names, colors]) {
     if (channelProp && channelProp.length !== n) {
       const propertyName = Object.keys({ channelProp })[0];
@@ -56,16 +63,17 @@ function loadMultiChannel(config: MultichannelConfig, data: ZarrPixelSource<stri
 
   visibilities = visibilities || getDefaultVisibilities(n);
   colors = colors || getDefaultColors(n, visibilities);
+  const contrastLimits = contrast_limits ?? (await (() => calcConstrastLimits(data[data.length - 1], channelAxis))());
 
   return {
     loader: data,
     name,
-    channel_axis: Number(channel_axis as number),
+    channel_axis: channelAxis,
     colors,
     names: names ?? range(n).map((i) => `channel_${i}`),
-    contrast_limits: contrast_limits ?? Array(n).fill([0, max]),
+    contrast_limits: contrastLimits,
     visibilities,
-    model_matrix: parseMatrix(config.model_matrix),
+    model_matrix: parseMatrix(model_matrix),
     defaults: {
       selection: Array(data[0].shape.length).fill(0),
       colormap,
@@ -123,20 +131,15 @@ export async function createSourceData(config: ImageLayerConfig): Promise<Source
   const loader = data.map((d) => new ZarrPixelSource(d, labels, tileSize));
   const [base] = loader;
 
-  // If contrast_limits not provided or are missing from omero metadata.
-  const max = base.dtype === 'Float32' ? 1 : DTYPE_VALUES[base.dtype].max;
-  // Now that we have data, try to figure out how to render initially.
-
   // If explicit channel axis is provided, try to load as multichannel.
   if ('channel_axis' in config || labels.includes('c')) {
     config = config as MultichannelConfig;
-    config.channel_axis = config.channel_axis ?? labels.indexOf('c');
-    return loadMultiChannel(config, loader, max);
+    return loadMultiChannel(config, loader, Number(config.channel_axis ?? labels.indexOf('c')));
   }
 
   const nDims = base.shape.length;
   if (nDims === 2 || !('channel_axis' in config)) {
-    return loadSingleChannel(config as SingleChannelConfig, loader, max);
+    return loadSingleChannel(config as SingleChannelConfig, loader);
   }
 
   throw Error('Failed to load image.');
@@ -180,10 +183,6 @@ export function initLayerStateFromSource(sourceData: SourceData): LayerState {
   }
   // set initial slider values to contrast_limits
   const sliderValues = [...contrastLimits];
-
-  if (!(loader[0].dtype in DTYPE_VALUES)) {
-    throw Error(`Dtype not supported, must be ${JSON.stringify(Object.keys(DTYPE_VALUES))}`);
-  }
 
   return {
     Layer,

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -1,8 +1,9 @@
-import { DTYPE_VALUES, ZarrPixelSource } from '@hms-dbmi/viv';
+import { ZarrPixelSource } from '@hms-dbmi/viv';
 import pMap from 'p-map';
 import { Group as ZarrGroup, openGroup, ZarrArray } from 'zarr';
 import type { ImageLayerConfig, SourceData } from './state';
 import {
+  calcConstrastLimits,
   getAttrsOnly,
   getDefaultColors,
   getDefaultVisibilities,
@@ -74,7 +75,7 @@ export async function loadWell(config: ImageLayerConfig, grp: ZarrGroup, wellAtt
   if ('omero' in imgAttrs) {
     meta = parseOmeroMeta(imgAttrs.omero, axis_labels);
   } else {
-    meta = defaultMeta(loaders[0].loader, axis_labels);
+    meta = await defaultMeta(loaders[0].loader, axis_labels);
   }
 
   const sourceData: SourceData = {
@@ -177,7 +178,7 @@ export async function loadPlate(config: ImageLayerConfig, grp: ZarrGroup, plateA
   if ('omero' in imgAttrs) {
     meta = parseOmeroMeta(imgAttrs.omero, axis_labels);
   } else {
-    meta = defaultMeta(loaders[0].loader, axis_labels);
+    meta = await defaultMeta(loaders[0].loader, axis_labels);
   }
 
   // Load Image to use for channel names, rendering settings, sizeZ, sizeT etc.
@@ -244,17 +245,17 @@ export async function loadOmeroMultiscales(
   };
 }
 
-function defaultMeta(loader: ZarrPixelSource<string[]>, axis_labels: string[]) {
+async function defaultMeta(loader: ZarrPixelSource<string[]>, axis_labels: string[]) {
   const channel_axis = axis_labels.indexOf('c');
-  const channel_count = loader.shape[channel_axis as number];
-  const max = loader.dtype === 'Float32' ? 1 : DTYPE_VALUES[loader.dtype].max;
+  const channel_count = loader.shape[channel_axis];
+  const contrast_limits = await calcConstrastLimits(loader, channel_axis);
   const visibilities = getDefaultVisibilities(channel_count);
   const colors = getDefaultColors(channel_count, visibilities);
   return {
     name: 'Image',
     names: range(channel_count).map((i) => `channel_${i}`),
     colors,
-    contrast_limits: Array(channel_count).fill([0, max]),
+    contrast_limits,
     visibilities,
     channel_axis: axis_labels.includes('c') ? axis_labels.indexOf('c') : null,
     defaultSelection: axis_labels.map(() => 0),

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -248,8 +248,8 @@ export async function loadOmeroMultiscales(
 async function defaultMeta(loader: ZarrPixelSource<string[]>, axis_labels: string[]) {
   const channel_axis = axis_labels.indexOf('c');
   const channel_count = loader.shape[channel_axis];
-  const contrast_limits = await calcConstrastLimits(loader, channel_axis);
   const visibilities = getDefaultVisibilities(channel_count);
+  const contrast_limits = await calcConstrastLimits(loader, channel_axis, visibilities);
   const colors = getDefaultColors(channel_count, visibilities);
   return {
     name: 'Image',

--- a/src/state.ts
+++ b/src/state.ts
@@ -72,7 +72,7 @@ export type SourceData = {
   channel_axis: number | null;
   colors: string[];
   names: string[];
-  contrast_limits: number[][];
+  contrast_limits: (number[] | undefined)[];
   visibilities: boolean[];
   defaults: {
     selection: number[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,7 @@
-import { ContainsArrayError, HTTPStore, openArray, openGroup, ZarrArray } from 'zarr';
+import { ContainsArrayError, HTTPStore, openArray, openGroup, ZarrArray, slice } from 'zarr';
 import type { Group as ZarrGroup } from 'zarr';
 import type { AsyncStore, Store } from 'zarr/types/storage/types';
+import type { ZarrPixelSource } from '@hms-dbmi/viv';
 import { Matrix4 } from '@math.gl/core/dist/esm';
 import { LRUCacheStore } from './lru-store';
 
@@ -193,4 +194,39 @@ export function parseMatrix(model_matrix?: string | number[]): Matrix4 {
     console.warn(msg);
   }
   return matrix;
+}
+
+export async function calcDataRange<S extends string[]>(
+  source: ZarrPixelSource<S>,
+  selection: number[]
+): Promise<[min: number, max: number]> {
+  if (source.dtype === 'Uint8') return [0, 255];
+  const { data } = await source.getRaster({ selection });
+  let minVal = Infinity;
+  let maxVal = -Infinity;
+  for (let i = 0; i < data.length; i++) {
+    if (data[i] > maxVal) maxVal = data[i];
+    if (data[i] < minVal) minVal = data[i];
+  }
+  if (minVal === maxVal) {
+    minVal = 0;
+    maxVal = 1;
+  }
+  return [minVal, maxVal];
+}
+
+export async function calcConstrastLimits<S extends string[]>(
+  source: ZarrPixelSource<S>,
+  channelAxis: number,
+  defaultSelection?: number[]
+): Promise<[min: number, max: number][]> {
+  const def = defaultSelection ?? source.shape.map(() => 0);
+  const csize = source.shape[channelAxis];
+  return Promise.all(
+    range(csize).map((i) => {
+      const selection = [...def];
+      selection[channelAxis] = i;
+      return calcDataRange(source, selection);
+    })
+  );
 }


### PR DESCRIPTION
~We can do something more sophisticated in the future, but this gives better behavior than the default.~

~For now if contrast limits are missing, the limits are computed up front (min/max of data) for the first N channels. Ideally we would have some type of reactive mechanism for computing the limits on demand (and caching the result), but we'd need a way to represent uncomputed limits in the state.~

@will-moore 

Contrast limits are now computed on-demand for the `SourceData`. The biggest change is that the type of `sourceData.contrast_limits` is now `(number[] | undefined)[]`. If a channel's contrast limits aren't provided (e.g `sourceData.contrast_limits[channel_index] === undefined`, we now calculate the data limits from low res and cache the result in `sourceData.contrast_limits[channel_index]` so that it isn't recomputed later.'


- https://deploy-preview-137--vizarr.netlify.app?source=https://uk1s3.embassy.ebi.ac.uk/ngff_sparse_hcs/9477_bf2raw_0_3_0.zarr/0/11/0

- https://deploy-preview-137--vizarr.netlify.app?source=https://uk1s3.embassy.ebi.ac.uk/ngff_sparse_hcs/9477_bf2raw_0_3_0.zarr/0/11/0&channel_axis=1

- https://deploy-preview-137--vizarr.netlify.app?source=https://uk1s3.embassy.ebi.ac.uk/ngff_sparse_hcs/9477_bf2raw_0_3_0.zarr

can compare with previous build:

- https://deploy-preview-136--vizarr.netlify.app?source=https://uk1s3.embassy.ebi.ac.uk/ngff_sparse_hcs/9477_bf2raw_0_3_0.zarr/0/11/0

- https://deploy-preview-136--vizarr.netlify.app?source=https://uk1s3.embassy.ebi.ac.uk/ngff_sparse_hcs/9477_bf2raw_0_3_0.zarr/0/11/0&channel_axis=1

- https://deploy-preview-136--vizarr.netlify.app?source=https://uk1s3.embassy.ebi.ac.uk/ngff_sparse_hcs/9477_bf2raw_0_3_0.zarr