### PR TITLE
Handle missing or empty channel.label

### DIFF
--- a/src/ome.ts
+++ b/src/ome.ts
@@ -276,11 +276,11 @@ function parseOmeroMeta({ rdefs, channels, name }: Ome.Omero, axes: Ome.Axis[]) 
   const visibilities: boolean[] = [];
   const names: string[] = [];
 
-  channels.forEach((c) => {
+  channels.forEach((c, index) => {
     colors.push(c.color);
     contrast_limits.push([c.window.start, c.window.end]);
     visibilities.push(c.active);
-    names.push(c.label);
+    names.push(c.label || "" + index);
   });
 
   const defaultSelection = axes.map((axis) => {


### PR DESCRIPTION
When looking at https://uk1s3.embassy.ebi.ac.uk/0.4_samples/coins/
I see the following error, caused by no `channel.label` in the `omero` metadata.
```
Warning: Each child in a list should have a unique "key" prop.
Check the render method of `AddChannelButton`. 
```
Although there probably *should* be a `channel.label` it isn't invalid for it to be missing, and it seems like this is worth handling.

With this fix, the error goes away, but I still see errors which I think are due to the `.zarray` responses showing no data in Firefox and Chrome. Not CORS issue but something else @sbesson?