### PR TITLE
feat: bump Viv to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "@hms-dbmi/vizarr",
       "version": "0.3.0",
       "dependencies": {
-        "@hms-dbmi/viv": "^0.12.5",
+        "@hms-dbmi/viv": "^0.13.0",
         "@material-ui/core": "^4.11.0",
         "@material-ui/icons": "^4.9.1",
         "deck.gl": "^8.6.7",
@@ -609,29 +609,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "node_modules/@hms-dbmi/viv": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.12.5.tgz",
-      "integrity": "sha512-oulveVJWO0wLpudWvSO/GPwx8j2Uc9TKlBeIQjo9wZTnbltlTLb2eta+G4AzrszPqCyU+tJmxRJlrZ0Yn+YM4w==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.13.0.tgz",
+      "integrity": "sha512-2f0nXMspBZ6gGTxQgdGlH7qQt5Nowcn7ct0AU4G6yiOud7w+jIDP/plqjFwFkQUxxblao0lGuJHPmqumpZQzxA==",
       "dependencies": {
-        "@math.gl/culling": "^3.4.2",
-        "fast-deep-equal": "^3.1.3",
-        "fast-xml-parser": "^3.16.0",
-        "geotiff": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.4.tar.gz",
-        "math.gl": "^3.3.0",
-        "quickselect": "^2.0.0",
-        "zarr": "^0.5.1"
-      },
-      "peerDependencies": {
-        "@deck.gl/core": "~8.6.0",
-        "@deck.gl/geo-layers": "~8.6.0",
-        "@deck.gl/layers": "~8.6.0",
-        "@deck.gl/react": "~8.6.0",
-        "@luma.gl/constants": "~8.5.3",
-        "@luma.gl/core": "~8.5.3",
-        "@luma.gl/shadertools": "~8.5.3",
-        "@luma.gl/webgl": "~8.5.3",
-        "react": "^16.12.0",
-        "react-dom": "^16.12.0"
+        "@vivjs/constants": "0.13.0",
+        "@vivjs/extensions": "0.13.0",
+        "@vivjs/layers": "0.13.0",
+        "@vivjs/loaders": "0.13.0",
+        "@vivjs/types": "0.13.0",
+        "@vivjs/viewers": "0.13.0",
+        "@vivjs/views": "0.13.0"
       }
     },
     "node_modules/@loaders.gl/3d-tiles": {
@@ -1107,14 +1095,9 @@
       }
     },
     "node_modules/@petamoriken/float16": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
-      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
-      "deprecated": "critical bug fixed in v3.1.1",
-      "dependencies": {
-        "lodash": ">=4.17.5 <5.0.0",
-        "lodash-es": ">=4.17.5 <5.0.0"
-      }
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.6.tgz",
+      "integrity": "sha512-3MUulwMtsdCA9lw8a/Kc0XDBJJVCkYTQ5aGd+///TbfkOMXoOGAzzoiYKwPEsLYZv7He7fKJ/mCacqKOO7REyg=="
     },
     "node_modules/@probe.gl/env": {
       "version": "3.5.0",
@@ -1245,6 +1228,104 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/@vivjs/constants": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/constants/-/constants-0.13.0.tgz",
+      "integrity": "sha512-37Pp5yVH9JAFZFLcNl1hGImFjhwaAtfNq7oQn1Olsj9gBbqvrQ6D1JytdZxIrdq1eBl1DrWy9+I2NqUbXyGNKA==",
+      "dependencies": {
+        "@luma.gl/constants": "8.5.13"
+      }
+    },
+    "node_modules/@vivjs/constants/node_modules/@luma.gl/constants": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.13.tgz",
+      "integrity": "sha512-mk16XITcWhyWFEZ98MRmbTluoT2ZrEbF4IrK/PPF+owZTlYFY4h2Yviv33Q61T3qYLbwSAv2eflltSEFWWFPPQ=="
+    },
+    "node_modules/@vivjs/extensions": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/extensions/-/extensions-0.13.0.tgz",
+      "integrity": "sha512-/I76Q+BBauzaOVRfJN4O5DFuJD7Dt/wsm+INYJJkIN1AfVObjvIhFcPTzOn+guPOiLQE0mbVMPMdTxREx08qCA==",
+      "dependencies": {
+        "@vivjs/constants": "0.13.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "8.6.7"
+      }
+    },
+    "node_modules/@vivjs/layers": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/layers/-/layers-0.13.0.tgz",
+      "integrity": "sha512-Pd2/fpr77heSbEfqudab2cGnmfpbDLqzuZW3IptZCNnc1hyu0mJvtg6EQ8Wr169kEGfOqG4vD75SOAgthJG5zA==",
+      "dependencies": {
+        "@math.gl/core": "^3.5.7",
+        "@math.gl/culling": "^3.5.7",
+        "@vivjs/constants": "0.13.0",
+        "@vivjs/extensions": "0.13.0",
+        "@vivjs/loaders": "0.13.0",
+        "@vivjs/types": "0.13.0"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "8.6.7",
+        "@deck.gl/geo-layers": "8.6.7",
+        "@deck.gl/layers": "8.6.7",
+        "@luma.gl/constants": "8.5.13",
+        "@luma.gl/core": "8.5.13",
+        "@luma.gl/engine": "8.5.13",
+        "@luma.gl/webgl": "8.5.13"
+      }
+    },
+    "node_modules/@vivjs/loaders": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/loaders/-/loaders-0.13.0.tgz",
+      "integrity": "sha512-H/he2SugBdH8h6mXJu++/aiakrda3V/N7BqOHeiTdGRhmTX/rOJgXP2MhcWlGTs4BzqCGe9Z/zNtSRyjQO5sAw==",
+      "dependencies": {
+        "@vivjs/types": "0.13.0",
+        "fast-xml-parser": "^3.16.0",
+        "geotiff": "^2.0.5",
+        "lzw-tiff-decoder": "^0.1.1",
+        "quickselect": "^2.0.0",
+        "zarr": "^0.5.1"
+      }
+    },
+    "node_modules/@vivjs/types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/types/-/types-0.13.0.tgz",
+      "integrity": "sha512-xBkz4i8pwieSe6DYWkiVMG5NdnPUa495mItZ1lWuA0QWF6KwF7enW+vYhAfkLetdKNzRnJUXnqx0udFPM4Ldeg==",
+      "dependencies": {
+        "@vivjs/constants": "0.13.0",
+        "math.gl": "^3.5.7"
+      }
+    },
+    "node_modules/@vivjs/viewers": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/viewers/-/viewers-0.13.0.tgz",
+      "integrity": "sha512-2XyYy8h8XEYdNg7KVBnYjp0qwEMD5dMULfioXuy3XnJRwvN47bv+TWmINChpDtdsEG+E3fruxgBtl/k/D3TH0A==",
+      "dependencies": {
+        "@vivjs/constants": "0.13.0",
+        "@vivjs/extensions": "0.13.0",
+        "@vivjs/views": "0.13.0",
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "@deck.gl/react": "8.6.7",
+        "react": "^16.8.0 || ^17.0.0"
+      }
+    },
+    "node_modules/@vivjs/views": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/views/-/views-0.13.0.tgz",
+      "integrity": "sha512-hqQ5Joewi4cfCHEI3lOFO73fxzbC9LQ7B7UzLN8s+pz4dnOuVqwyv8uTT4+P1nfpzUWqlrvrm9aCwkbfWN8WrQ==",
+      "dependencies": {
+        "@math.gl/core": "^3.5.7",
+        "@vivjs/layers": "0.13.0",
+        "@vivjs/loaders": "0.13.0",
+        "math.gl": "^3.5.7"
+      },
+      "peerDependencies": {
+        "@deck.gl/core": "8.6.7",
+        "@deck.gl/layers": "8.6.7"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -1303,14 +1384,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
-      }
-    },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -1391,11 +1464,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "node_modules/content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
     },
     "node_modules/convert-source-map": {
       "version": "1.8.0",
@@ -1964,15 +2032,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -2056,23 +2115,19 @@
       }
     },
     "node_modules/geotiff": {
-      "version": "1.0.4",
-      "resolved": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.4.tar.gz",
-      "integrity": "sha512-pyZTspixWFUrFEQE9izjICtfWXlcbvYWyzJtcDpHwiz3jP5IKF1ItLfgekMhsvGJ9eLXOgF0OEp25baMz5iAgQ==",
-      "license": "MIT",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.5.tgz",
+      "integrity": "sha512-U5kVYm118YAmw2swiLu8rhfrYnDKOFI7VaMjuQwcq6Intuuid9Pyb4jjxYUxxkq8kOu2r7Am0Rmb52PObGp4pQ==",
       "dependencies": {
-        "@petamoriken/float16": "^1.0.7",
-        "content-type-parser": "^1.0.2",
-        "lerc": "^2.0.0",
-        "lru-cache": "^6.0.0",
-        "lzw-tiff-decoder": "^0.1.1",
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
-        "threads": "^1.3.1",
-        "txml": "^5.0.0"
+        "quick-lru": "^6.1.0",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2"
       },
       "engines": {
-        "browsers": "defaults",
         "node": ">=10.19"
       }
     },
@@ -2228,11 +2283,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
     "node_modules/internmap": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
@@ -2254,17 +2304,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
-    },
-    "node_modules/is-observable": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
-      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/jotai": {
       "version": "1.5.3",
@@ -2457,19 +2496,9 @@
       "integrity": "sha512-LY3nrmfXl+wZZdPxgJ3ZmLvG+wkOZZP3/dr4RbQj1Pk3Qwz44esOOSFFVQJcNWpXAtiNIC66WgXufX/SYgYz6A=="
     },
     "node_modules/lerc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lerc/-/lerc-2.0.0.tgz",
-      "integrity": "sha512-7qo1Mq8ZNmaR4USHHm615nEW2lPeeWJ3bTyoqFbd35DLx0LUH7C6ptt5FDCTAlbIzs3+WKrk5SkJvw8AFDE2hg=="
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
     "node_modules/long": {
       "version": "3.2.0",
@@ -2488,17 +2517,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/lzw-tiff-decoder": {
@@ -2572,11 +2590,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/observable-fns": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
-      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
-    },
     "node_modules/p-map": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -2623,9 +2636,9 @@
       "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "node_modules/parse-headers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
-      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "node_modules/parseqs": {
       "version": "0.0.6",
@@ -2746,9 +2759,9 @@
       "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/quick-lru": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.0.2.tgz",
-      "integrity": "sha512-H5ZVbbMzZEl+wEwiMP3v/b7ji+GrM3MRiy62LJbpI+F5+9RNcSKrjz7T0jIJVrlMfMxr7ZG0EGswJiABt75LDg==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
+      "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q==",
       "engines": {
         "node": ">=12"
       },
@@ -2813,19 +2826,6 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/reference-spec-reader": {
@@ -2963,33 +2963,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
@@ -3031,45 +3004,10 @@
         "texture-compressor": "bin/texture-compressor.js"
       }
     },
-    "node_modules/threads": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/threads/-/threads-1.7.0.tgz",
-      "integrity": "sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==",
-      "dependencies": {
-        "callsites": "^3.1.0",
-        "debug": "^4.2.0",
-        "is-observable": "^2.1.0",
-        "observable-fns": "^0.6.1"
-      },
-      "funding": {
-        "url": "https://github.com/andywer/threads.js?sponsor=1"
-      },
-      "optionalDependencies": {
-        "tiny-worker": ">= 2"
-      }
-    },
-    "node_modules/through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
-    },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
-    "node_modules/tiny-worker": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
-      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
-      "optional": true,
-      "dependencies": {
-        "esm": "^3.2.25"
-      }
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -3078,14 +3016,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/txml": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-5.1.1.tgz",
-      "integrity": "sha512-TwMDLnXQ09enNaxybLVvKZU7rqog8LgnuAs4ZYXM0nV0eu10iLsSFwlX3AEknAXXtH1wT3CYfoiXAjyBexcmuw==",
-      "dependencies": {
-        "through2": "^3.0.1"
       }
     },
     "node_modules/typescript": {
@@ -3109,11 +3039,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/vite": {
       "version": "3.0.2",
@@ -3156,6 +3081,11 @@
         }
       }
     },
+    "node_modules/web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
+    },
     "node_modules/ws": {
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
@@ -3176,6 +3106,11 @@
         }
       }
     },
+    "node_modules/xml-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.2.0.tgz",
+      "integrity": "sha512-z4unVPZruEDC3tfyd7wvWfjclnMz34iwQpv8H28H+qREpjKkR083MBvcrWXfJrIcrSmHR5ghguOcgQqWdnBpVA=="
+    },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
@@ -3183,11 +3118,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yeast": {
       "version": "0.1.2",
@@ -3631,17 +3561,17 @@
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@hms-dbmi/viv": {
-      "version": "0.12.5",
-      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.12.5.tgz",
-      "integrity": "sha512-oulveVJWO0wLpudWvSO/GPwx8j2Uc9TKlBeIQjo9wZTnbltlTLb2eta+G4AzrszPqCyU+tJmxRJlrZ0Yn+YM4w==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@hms-dbmi/viv/-/viv-0.13.0.tgz",
+      "integrity": "sha512-2f0nXMspBZ6gGTxQgdGlH7qQt5Nowcn7ct0AU4G6yiOud7w+jIDP/plqjFwFkQUxxblao0lGuJHPmqumpZQzxA==",
       "requires": {
-        "@math.gl/culling": "^3.4.2",
-        "fast-deep-equal": "^3.1.3",
-        "fast-xml-parser": "^3.16.0",
-        "geotiff": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.4.tar.gz",
-        "math.gl": "^3.3.0",
-        "quickselect": "^2.0.0",
-        "zarr": "^0.5.1"
+        "@vivjs/constants": "0.13.0",
+        "@vivjs/extensions": "0.13.0",
+        "@vivjs/layers": "0.13.0",
+        "@vivjs/loaders": "0.13.0",
+        "@vivjs/types": "0.13.0",
+        "@vivjs/viewers": "0.13.0",
+        "@vivjs/views": "0.13.0"
       }
     },
     "@loaders.gl/3d-tiles": {
@@ -4016,13 +3946,9 @@
       }
     },
     "@petamoriken/float16": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-1.1.1.tgz",
-      "integrity": "sha512-0r8nE5Q60tj3FbWWYLjAdGnWZgP7CMWXNaI5UsNzypRyxLDb/uvOl5SDw8GcPNu6pSTOt+KSI+0oL6fhSpNOFQ==",
-      "requires": {
-        "lodash": ">=4.17.5 <5.0.0",
-        "lodash-es": ">=4.17.5 <5.0.0"
-      }
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.6.6.tgz",
+      "integrity": "sha512-3MUulwMtsdCA9lw8a/Kc0XDBJJVCkYTQ5aGd+///TbfkOMXoOGAzzoiYKwPEsLYZv7He7fKJ/mCacqKOO7REyg=="
     },
     "@probe.gl/env": {
       "version": "3.5.0",
@@ -4146,6 +4072,86 @@
         "resolve": "^1.20.0"
       }
     },
+    "@vivjs/constants": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/constants/-/constants-0.13.0.tgz",
+      "integrity": "sha512-37Pp5yVH9JAFZFLcNl1hGImFjhwaAtfNq7oQn1Olsj9gBbqvrQ6D1JytdZxIrdq1eBl1DrWy9+I2NqUbXyGNKA==",
+      "requires": {
+        "@luma.gl/constants": "8.5.13"
+      },
+      "dependencies": {
+        "@luma.gl/constants": {
+          "version": "8.5.13",
+          "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-8.5.13.tgz",
+          "integrity": "sha512-mk16XITcWhyWFEZ98MRmbTluoT2ZrEbF4IrK/PPF+owZTlYFY4h2Yviv33Q61T3qYLbwSAv2eflltSEFWWFPPQ=="
+        }
+      }
+    },
+    "@vivjs/extensions": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/extensions/-/extensions-0.13.0.tgz",
+      "integrity": "sha512-/I76Q+BBauzaOVRfJN4O5DFuJD7Dt/wsm+INYJJkIN1AfVObjvIhFcPTzOn+guPOiLQE0mbVMPMdTxREx08qCA==",
+      "requires": {
+        "@vivjs/constants": "0.13.0"
+      }
+    },
+    "@vivjs/layers": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/layers/-/layers-0.13.0.tgz",
+      "integrity": "sha512-Pd2/fpr77heSbEfqudab2cGnmfpbDLqzuZW3IptZCNnc1hyu0mJvtg6EQ8Wr169kEGfOqG4vD75SOAgthJG5zA==",
+      "requires": {
+        "@math.gl/core": "^3.5.7",
+        "@math.gl/culling": "^3.5.7",
+        "@vivjs/constants": "0.13.0",
+        "@vivjs/extensions": "0.13.0",
+        "@vivjs/loaders": "0.13.0",
+        "@vivjs/types": "0.13.0"
+      }
+    },
+    "@vivjs/loaders": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/loaders/-/loaders-0.13.0.tgz",
+      "integrity": "sha512-H/he2SugBdH8h6mXJu++/aiakrda3V/N7BqOHeiTdGRhmTX/rOJgXP2MhcWlGTs4BzqCGe9Z/zNtSRyjQO5sAw==",
+      "requires": {
+        "@vivjs/types": "0.13.0",
+        "fast-xml-parser": "^3.16.0",
+        "geotiff": "^2.0.5",
+        "lzw-tiff-decoder": "^0.1.1",
+        "quickselect": "^2.0.0",
+        "zarr": "^0.5.1"
+      }
+    },
+    "@vivjs/types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/types/-/types-0.13.0.tgz",
+      "integrity": "sha512-xBkz4i8pwieSe6DYWkiVMG5NdnPUa495mItZ1lWuA0QWF6KwF7enW+vYhAfkLetdKNzRnJUXnqx0udFPM4Ldeg==",
+      "requires": {
+        "@vivjs/constants": "0.13.0",
+        "math.gl": "^3.5.7"
+      }
+    },
+    "@vivjs/viewers": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/viewers/-/viewers-0.13.0.tgz",
+      "integrity": "sha512-2XyYy8h8XEYdNg7KVBnYjp0qwEMD5dMULfioXuy3XnJRwvN47bv+TWmINChpDtdsEG+E3fruxgBtl/k/D3TH0A==",
+      "requires": {
+        "@vivjs/constants": "0.13.0",
+        "@vivjs/extensions": "0.13.0",
+        "@vivjs/views": "0.13.0",
+        "fast-deep-equal": "^3.1.3"
+      }
+    },
+    "@vivjs/views": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@vivjs/views/-/views-0.13.0.tgz",
+      "integrity": "sha512-hqQ5Joewi4cfCHEI3lOFO73fxzbC9LQ7B7UzLN8s+pz4dnOuVqwyv8uTT4+P1nfpzUWqlrvrm9aCwkbfWN8WrQ==",
+      "requires": {
+        "@math.gl/core": "^3.5.7",
+        "@vivjs/layers": "0.13.0",
+        "@vivjs/loaders": "0.13.0",
+        "math.gl": "^3.5.7"
+      }
+    },
     "aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -4189,11 +4195,6 @@
         "node-releases": "^2.0.1",
         "picocolors": "^1.0.0"
       }
-    },
-    "callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "caniuse-lite": {
       "version": "1.0.30001367",
@@ -4254,11 +4255,6 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "content-type-parser": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
-      "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ=="
     },
     "convert-source-map": {
       "version": "1.8.0",
@@ -4614,12 +4610,6 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "optional": true
-    },
     "estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
@@ -4683,18 +4673,17 @@
       "dev": true
     },
     "geotiff": {
-      "version": "https://github.com/ilan-gold/geotiff.js/archive/refs/tags/viv-0.0.4.tar.gz",
-      "integrity": "sha512-pyZTspixWFUrFEQE9izjICtfWXlcbvYWyzJtcDpHwiz3jP5IKF1ItLfgekMhsvGJ9eLXOgF0OEp25baMz5iAgQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.0.5.tgz",
+      "integrity": "sha512-U5kVYm118YAmw2swiLu8rhfrYnDKOFI7VaMjuQwcq6Intuuid9Pyb4jjxYUxxkq8kOu2r7Am0Rmb52PObGp4pQ==",
       "requires": {
-        "@petamoriken/float16": "^1.0.7",
-        "content-type-parser": "^1.0.2",
-        "lerc": "^2.0.0",
-        "lru-cache": "^6.0.0",
-        "lzw-tiff-decoder": "^0.1.1",
+        "@petamoriken/float16": "^3.4.7",
+        "lerc": "^3.0.0",
         "pako": "^2.0.4",
         "parse-headers": "^2.0.2",
-        "threads": "^1.3.1",
-        "txml": "^5.0.0"
+        "quick-lru": "^6.1.0",
+        "web-worker": "^1.2.0",
+        "xml-utils": "^1.0.2"
       }
     },
     "gl-matrix": {
@@ -4805,11 +4794,6 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
     },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
     "internmap": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
@@ -4828,11 +4812,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
       "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
-    },
-    "is-observable": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-2.1.0.tgz",
-      "integrity": "sha512-DailKdLb0WU+xX8K5w7VsJhapwHLZ9jjmazqCJq4X12CTgqq73TKnbRcnSLuXYPOoLQgV5IrD7ePiX/h1vnkBw=="
     },
     "jotai": {
       "version": "1.5.3",
@@ -4964,19 +4943,9 @@
       "integrity": "sha512-LY3nrmfXl+wZZdPxgJ3ZmLvG+wkOZZP3/dr4RbQj1Pk3Qwz44esOOSFFVQJcNWpXAtiNIC66WgXufX/SYgYz6A=="
     },
     "lerc": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/lerc/-/lerc-2.0.0.tgz",
-      "integrity": "sha512-7qo1Mq8ZNmaR4USHHm615nEW2lPeeWJ3bTyoqFbd35DLx0LUH7C6ptt5FDCTAlbIzs3+WKrk5SkJvw8AFDE2hg=="
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash-es": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
     "long": {
       "version": "3.2.0",
@@ -4989,14 +4958,6 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
       }
     },
     "lzw-tiff-decoder": {
@@ -5054,11 +5015,6 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
-    "observable-fns": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/observable-fns/-/observable-fns-0.6.1.tgz",
-      "integrity": "sha512-9gRK4+sRWzeN6AOewNBTLXir7Zl/i3GB6Yl26gK4flxz8BXVpD3kt8amREmWNb0mxYOGDotvE5a4N+PtGGKdkg=="
-    },
     "p-map": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
@@ -5087,9 +5043,9 @@
       "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "parse-headers": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.4.tgz",
-      "integrity": "sha512-psZ9iZoCNFLrgRjZ1d8mn0h9WRqJwFxM9q3x7iUjN/YT2OksthDJ5TiPCu2F38kS4zutqfW+YdVVkBZZx3/1aw=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "parseqs": {
       "version": "0.0.6",
@@ -5184,9 +5140,9 @@
       "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "quick-lru": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.0.2.tgz",
-      "integrity": "sha512-H5ZVbbMzZEl+wEwiMP3v/b7ji+GrM3MRiy62LJbpI+F5+9RNcSKrjz7T0jIJVrlMfMxr7ZG0EGswJiABt75LDg=="
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.1.tgz",
+      "integrity": "sha512-S27GBT+F0NTRiehtbrgaSE1idUAJ5bX8dPAQTdylEyNlrdcH5X4Lz7Edz3DYzecbsCluD5zO8ZNEe04z3D3u6Q=="
     },
     "quickselect": {
       "version": "2.0.0",
@@ -5232,16 +5188,6 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
-      }
-    },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
       }
     },
     "reference-spec-reader": {
@@ -5352,21 +5298,6 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
-      }
-    },
     "strnum": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
@@ -5396,54 +5327,16 @@
         "image-size": "^0.7.4"
       }
     },
-    "threads": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/threads/-/threads-1.7.0.tgz",
-      "integrity": "sha512-Mx5NBSHX3sQYR6iI9VYbgHKBLisyB+xROCBGjjWm1O9wb9vfLxdaGtmT/KCjUqMsSNW6nERzCW3T6H43LqjDZQ==",
-      "requires": {
-        "callsites": "^3.1.0",
-        "debug": "^4.2.0",
-        "is-observable": "^2.1.0",
-        "observable-fns": "^0.6.1",
-        "tiny-worker": ">= 2"
-      }
-    },
-    "through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
-    },
     "tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
-    "tiny-worker": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-worker/-/tiny-worker-2.3.0.tgz",
-      "integrity": "sha512-pJ70wq5EAqTAEl9IkGzA+fN0836rycEuz2Cn6yeZ6FRzlVS5IDOkFHpIoEsksPRQV34GDqXm65+OlnZqUSyK2g==",
-      "optional": true,
-      "requires": {
-        "esm": "^3.2.25"
-      }
     },
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
-    },
-    "txml": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/txml/-/txml-5.1.1.tgz",
-      "integrity": "sha512-TwMDLnXQ09enNaxybLVvKZU7rqog8LgnuAs4ZYXM0nV0eu10iLsSFwlX3AEknAXXtH1wT3CYfoiXAjyBexcmuw==",
-      "requires": {
-        "through2": "^3.0.1"
-      }
     },
     "typescript": {
       "version": "4.5.5",
@@ -5456,11 +5349,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "vite": {
       "version": "3.0.2",
@@ -5475,20 +5363,25 @@
         "rollup": "^2.75.6"
       }
     },
+    "web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA=="
+    },
     "ws": {
       "version": "8.2.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
       "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
     },
+    "xml-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.2.0.tgz",
+      "integrity": "sha512-z4unVPZruEDC3tfyd7wvWfjclnMz34iwQpv8H28H+qREpjKkR083MBvcrWXfJrIcrSmHR5ghguOcgQqWdnBpVA=="
+    },
     "xmlhttprequest-ssl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
       "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A=="
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yeast": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@hms-dbmi/vizarr",
   "version": "0.3.0",
   "dependencies": {
-    "@hms-dbmi/viv": "^0.12.5",
+    "@hms-dbmi/viv": "^0.13.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
     "deck.gl": "^8.6.7",


### PR DESCRIPTION
Bump Viv to `v0.0.11` (with `@vivjs/*`) modules
