### PR TITLE
Handle missing omero.rdef

### DIFF
--- a/src/ome.ts
+++ b/src/ome.ts
@@ -268,8 +268,8 @@ async function defaultMeta(loader: ZarrPixelSource<string[]>, axis_labels: strin
 }
 
 function parseOmeroMeta({ rdefs, channels, name }: Ome.Omero, axes: Ome.Axis[]) {
-  const t = rdefs.defaultT ?? 0;
-  const z = rdefs.defaultZ ?? 0;
+  const t = rdefs?.defaultT ?? 0;
+  const z = rdefs?.defaultZ ?? 0;
 
   const colors: string[] = [];
   const contrast_limits: [min: number, max: number][] = [];


### PR DESCRIPTION
I just tried viewing data at https://public.czbiohub.org/royerlab/zebrahub/imaging/single-objective/ZSNS001_tail.ome.zarr and this failed because the `omero` metadata has no `rdef` object:

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'defaultT')
    at Vv (index-da7a8e3f.js:3887:11929)
    at h$ (index-da7a8e3f.js:3887:11413)
    at async Object.write (index-da7a8e3f.js:3887:15559)
```

This fix simply allows us to use the 0 default for Z and T, which allows the image to be viewed, although the down-sampling in Z causes other issues:

![Screenshot 2023-03-29 at 17 10 14](https://user-images.githubusercontent.com/900055/228601674-678dc178-b0ef-4c23-9097-be7d045150d8.png)
