### PR TITLE
Handle no channel axis

### DIFF
--- a/src/ome.ts
+++ b/src/ome.ts
@@ -255,7 +255,7 @@ export async function loadOmeroMultiscales(
 
 async function defaultMeta(loader: ZarrPixelSource<string[]>, axis_labels: string[]) {
   const channel_axis = axis_labels.indexOf('c');
-  const channel_count = loader.shape[channel_axis];
+  const channel_count = channel_axis == -1 ? 1 : loader.shape[channel_axis];
   const visibilities = getDefaultVisibilities(channel_count);
   const contrast_limits = await calcConstrastLimits(loader, channel_axis, visibilities);
   const colors = getDefaultColors(channel_count, visibilities);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -262,7 +262,7 @@ export async function calcConstrastLimits<S extends string[]>(
   const def = defaultSelection ?? source.shape.map(() => 0);
   const csize = source.shape[channelAxis];
 
-  if (csize !== visibilities.length) {
+  if (csize !== visibilities.length && channelAxis > -1) {
     throw new Error("provided visibilities don't match number of channels");
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -259,6 +259,7 @@ export async function calcConstrastLimits<S extends string[]>(
   visibilities: boolean[],
   defaultSelection?: number[]
 ): Promise<([min: number, max: number] | undefined)[]> {
+  // channelAxis can be -1 if there is no 'c' dimension
   const def = defaultSelection ?? source.shape.map(() => 0);
   const csize = source.shape[channelAxis];
 
@@ -270,7 +271,9 @@ export async function calcConstrastLimits<S extends string[]>(
     visibilities.map(async (isVisible, i) => {
       if (!isVisible) return undefined; // don't compute non-visible channels
       const selection = [...def];
-      selection[channelAxis] = i;
+      if (channelAxis > -1) {
+        selection[channelAxis] = i;
+      }
       return calcDataRange(source, selection);
     })
   );


### PR DESCRIPTION
This fixes an issue I saw when trying to view a simple NGFF Plate created by the example code at https://github.com/ome/ome-zarr-py/pull/317/files

The Images in this Plate have no `omero` metadata and they also have no `c` dimension (just `zyx`).
In this case, the `defaultMeta()` logic fails to calculate contrast limits.
Allowing that code to work with `channelAxis` being `-1` looks like the simplest fix.