### PR TITLE
Display server error in the page

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -128,17 +128,23 @@ export type ControllerProps<T = object> = {
   layerAtom: PrimitiveAtom<WithId<LayerState>>;
 } & T;
 
+export const sourceErrorAtom = atom<string | null>(null);
+
 export const sourceInfoAtom = atom<WithId<SourceData>[]>([]);
 
 export const addImageAtom = atom(null, async (get, set, config: ImageLayerConfig) => {
   const { createSourceData } = await import("./io");
   const id = Math.random().toString(36).slice(2);
-  const sourceData = await createSourceData(config);
-  const prevSourceInfo = get(sourceInfoAtom);
-  if (!sourceData.name) {
-    sourceData.name = `image_${Object.keys(prevSourceInfo).length}`;
+  try {
+    const sourceData = await createSourceData(config);
+    const prevSourceInfo = get(sourceInfoAtom);
+    if (!sourceData.name) {
+      sourceData.name = `image_${Object.keys(prevSourceInfo).length}`;
+    }
+    set(sourceInfoAtom, [...prevSourceInfo, { id, ...sourceData }]);
+  } catch (err) {
+    set(sourceErrorAtom, (err as Error).message);
   }
-  set(sourceInfoAtom, [...prevSourceInfo, { id, ...sourceData }]);
 });
 
 export const sourceInfoAtomAtoms = splitAtom(sourceInfoAtom);


### PR DESCRIPTION
Hi,
currently, if the server replies with an error, vizarr displays a black page. We would like to display an informative error to the user, so we are proposing these changes.

Notice that, since we are also using authentication, we would also like to display 403 Forbidden messages, but this is not possible at the moment since Zarrita handles 403 and 404 in the same way.

Here is the `handle_response` function in zarrita.js (see https://github.com/manzt/zarrita.js/blob/7ff33a59803ee37cbeec5b4aa61528d8bd021691/packages/storage/src/fetch.ts#L19):

```typescript
async function handle_response(
	response: Response,
): Promise<Uint8Array | undefined> {
	if (response.status === 404 || response.status === 403) {
		return undefined;
	}
	if (response.status === 200 || response.status === 206) {
		return new Uint8Array(await response.arrayBuffer());
	}
	throw new Error(
		`Unexpected response status ${response.status} ${response.statusText}`,
	);
}
```

@manzt Would it be possible to throw an error also for the 403 case?

Thanks