### PR TITLE
fix: patch `@vivjs/loaders` to exclude `zarr` and `lzw-tiff-decoder` from final bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,5 +36,10 @@
     "typescript": "^5.8.2",
     "vite": "^6.2.0"
   },
-  "packageManager": "pnpm@9.5.0"
+  "packageManager": "pnpm@9.5.0",
+  "pnpm": {
+    "patchedDependencies": {
+      "@vivjs/loaders@0.17.1": "patches/@vivjs__loaders@0.17.1.patch"
+    }
+  }
 }

--- a/patches/@vivjs__loaders@0.17.1.patch
+++ b/patches/@vivjs__loaders@0.17.1.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index b709ea0b4eb932f46b304b4cd8d241ac09e37a8b..37788b9807822f2d4bc257a5079f534a1d34dea7 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -1,8 +1,6 @@
+ import { BaseDecoder, fromBlob, fromFile, fromUrl, GeoTIFFImage, addDecoder } from 'geotiff';
+-import { decompress } from 'lzw-tiff-decoder';
+ import quickselect from 'quickselect';
+ import * as z from 'zod';
+-import { KeyError, openGroup, HTTPStore } from 'zarr';
+ 
+ var __defProp$3 = Object.defineProperty;
+ var __defNormalProp$3 = (obj, key, value) => key in obj ? __defProp$3(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@vivjs/loaders@0.17.1':
+    hash: auxsjwuajoz3k5rha2oxpwrlfm
+    path: patches/@vivjs__loaders@0.17.1.patch
+
 importers:
 
   .:
@@ -2301,7 +2306,7 @@ snapshots:
       '@vivjs/constants': 0.17.1
       '@vivjs/extensions': 0.17.1(@deck.gl/core@9.0.41)
       '@vivjs/layers': 0.17.1(@deck.gl/core@9.0.41)(@deck.gl/geo-layers@9.0.41(@deck.gl/core@9.0.41)(@deck.gl/extensions@9.0.41(@deck.gl/core@9.0.41)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/mesh-layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@luma.gl/constants@9.0.28)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28))(@luma.gl/shadertools@9.0.28(@luma.gl/core@9.0.28))(@luma.gl/webgl@9.0.28(@luma.gl/core@9.0.28))
-      '@vivjs/loaders': 0.17.1
+      '@vivjs/loaders': 0.17.1(patch_hash=auxsjwuajoz3k5rha2oxpwrlfm)
       '@vivjs/types': 0.17.1
       '@vivjs/viewers': 0.17.1(@deck.gl/core@9.0.41)(@deck.gl/geo-layers@9.0.41(@deck.gl/core@9.0.41)(@deck.gl/extensions@9.0.41(@deck.gl/core@9.0.41)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/mesh-layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/react@9.0.41(@deck.gl/core@9.0.41)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@luma.gl/constants@9.0.28)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28))(@luma.gl/shadertools@9.0.28(@luma.gl/core@9.0.28))(@luma.gl/webgl@9.0.28(@luma.gl/core@9.0.28))(react@18.3.1)
       '@vivjs/views': 0.17.1(@deck.gl/core@9.0.41)(@deck.gl/geo-layers@9.0.41(@deck.gl/core@9.0.41)(@deck.gl/extensions@9.0.41(@deck.gl/core@9.0.41)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/mesh-layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@luma.gl/constants@9.0.28)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28))(@luma.gl/shadertools@9.0.28(@luma.gl/core@9.0.28))(@luma.gl/webgl@9.0.28(@luma.gl/core@9.0.28))
@@ -3029,10 +3034,10 @@ snapshots:
       '@math.gl/culling': 4.1.0
       '@vivjs/constants': 0.17.1
       '@vivjs/extensions': 0.17.1(@deck.gl/core@9.0.41)
-      '@vivjs/loaders': 0.17.1
+      '@vivjs/loaders': 0.17.1(patch_hash=auxsjwuajoz3k5rha2oxpwrlfm)
       '@vivjs/types': 0.17.1
 
-  '@vivjs/loaders@0.17.1':
+  '@vivjs/loaders@0.17.1(patch_hash=auxsjwuajoz3k5rha2oxpwrlfm)':
     dependencies:
       '@vivjs/types': 0.17.1
       geotiff: 2.1.3
@@ -3075,7 +3080,7 @@ snapshots:
       '@deck.gl/layers': 9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28))
       '@math.gl/core': 4.1.0
       '@vivjs/layers': 0.17.1(@deck.gl/core@9.0.41)(@deck.gl/geo-layers@9.0.41(@deck.gl/core@9.0.41)(@deck.gl/extensions@9.0.41(@deck.gl/core@9.0.41)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/mesh-layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@deck.gl/layers@9.0.41(@deck.gl/core@9.0.41)(@loaders.gl/core@4.3.3)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28)))(@luma.gl/constants@9.0.28)(@luma.gl/core@9.0.28)(@luma.gl/engine@9.0.28(@luma.gl/core@9.0.28))(@luma.gl/shadertools@9.0.28(@luma.gl/core@9.0.28))(@luma.gl/webgl@9.0.28(@luma.gl/core@9.0.28))
-      '@vivjs/loaders': 0.17.1
+      '@vivjs/loaders': 0.17.1(patch_hash=auxsjwuajoz3k5rha2oxpwrlfm)
       math.gl: 4.1.0
     transitivePeerDependencies:
       - '@deck.gl/geo-layers'


### PR DESCRIPTION
`@hms-dbmi/viv` relies on zarr.js, which introduces side effects that
force bundlers to include it even though we don't use any of its
functionality. Similarly, the LZW decompression import is just for
`geotiff` and isn't unused in our context.

This patch removes these imports, preventing large, unnecessary
dependencies from being included in the bundle. It takes the final
vite entrypoint from ~1.8Mb to ~1.3Mb (500Kb).

To visualize the outputs with esbuild:

**before**

<img width="1455" alt="image" src="https://github.com/user-attachments/assets/eb4dbdd7-a4f6-4005-b932-a7177a92a359" />

**after**

<img width="1447" alt="image" src="https://github.com/user-attachments/assets/4d96d434-156d-4d59-91d5-e182a668a1bf" />



