### PR TITLE
Update ZarrPixelSource compatability

### DIFF
--- a/src/gridLayer.ts
+++ b/src/gridLayer.ts
@@ -9,7 +9,7 @@ import type { BaseLayerProps } from "./state";
 import { assert } from "./utils";
 
 export interface GridLoader {
-  loader: ZarrPixelSource<string[]>;
+  loader: ZarrPixelSource;
   row: number;
   col: number;
   name: string;

--- a/src/io.ts
+++ b/src/io.ts
@@ -7,10 +7,7 @@ import { loadOmeroMultiscales, loadPlate, loadWell } from "./ome";
 import type { ImageLayerConfig, LayerState, MultichannelConfig, SingleChannelConfig, SourceData } from "./state";
 import * as utils from "./utils";
 
-async function loadSingleChannel(
-  config: SingleChannelConfig,
-  data: Array<ZarrPixelSource<string[]>>,
-): Promise<SourceData> {
+async function loadSingleChannel(config: SingleChannelConfig, data: Array<ZarrPixelSource>): Promise<SourceData> {
   const { color, contrast_limits, visibility, name, colormap = "", opacity = 1 } = config;
   const lowres = data[data.length - 1];
   const selection = Array(data[0].shape.length).fill(0);
@@ -35,7 +32,7 @@ async function loadSingleChannel(
 
 async function loadMultiChannel(
   config: MultichannelConfig,
-  data: ZarrPixelSource<string[]>[],
+  data: Array<ZarrPixelSource>,
   channelAxis: number,
 ): Promise<SourceData> {
   const { names, contrast_limits, name, model_matrix, opacity = 1, colormap = "" } = config;

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -279,7 +279,7 @@ type Meta = {
   defaultSelection: Array<number>;
 };
 
-async function defaultMeta(loader: ZarrPixelSource<string[]>, axis_labels: string[]): Promise<Meta> {
+async function defaultMeta(loader: ZarrPixelSource, axis_labels: string[]): Promise<Meta> {
   const channel_axis = axis_labels.indexOf("c");
   const channel_count = channel_axis === -1 ? 1 : loader.shape[channel_axis];
   const visibilities = utils.getDefaultVisibilities(channel_count);

--- a/src/state.ts
+++ b/src/state.ts
@@ -84,17 +84,17 @@ export interface BaseLayerProps {
 }
 
 interface MultiscaleImageLayerProps extends BaseLayerProps {
-  loader: ZarrPixelSource<string[]>[];
+  loader: Array<ZarrPixelSource>;
 }
 
 interface ImageLayerProps extends BaseLayerProps {
-  loader: ZarrPixelSource<string[]>;
+  loader: ZarrPixelSource;
 }
 
 type LayerMap = {
   image: [typeof ImageLayer, ImageLayerProps];
   multiscale: [typeof MultiscaleImageLayer, MultiscaleImageLayerProps];
-  grid: [GridLayer, { loader: ZarrPixelSource<string[]> | ZarrPixelSource<string[]>[] } & GridLayerProps];
+  grid: [GridLayer, { loader: ZarrPixelSource | Array<ZarrPixelSource> } & GridLayerProps];
 };
 
 // biome-ignore lint/suspicious/noExplicitAny: Need a catch all for layer types

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -290,8 +290,8 @@ export async function calcDataRange(
   return [minVal, maxVal];
 }
 
-export async function calcConstrastLimits<S extends string[]>(
-  source: ZarrPixelSource<S>,
+export async function calcConstrastLimits(
+  source: ZarrPixelSource,
   channelAxis: number,
   visibilities: boolean[],
   defaultSelection?: number[],


### PR DESCRIPTION
Coerces various various `zarrita` data types that aren't supported by Viv into something Viv-compatible
