### PR TITLE
If rdefs.model is greyscale, channel is white

### DIFF
--- a/src/ome.ts
+++ b/src/ome.ts
@@ -332,6 +332,7 @@ async function defaultMeta(loader: ZarrPixelSource, axis_labels: string[]): Prom
 function parseOmeroMeta({ rdefs, channels, name }: Ome.Omero, axes: Ome.Axis[]): Meta {
   const t = rdefs?.defaultT ?? 0;
   const z = rdefs?.defaultZ ?? 0;
+  const greyscale = rdefs?.model === "greyscale";
 
   const colors: string[] = [];
   const contrast_limits: [min: number, max: number][] = [];
@@ -344,6 +345,10 @@ function parseOmeroMeta({ rdefs, channels, name }: Ome.Omero, axes: Ome.Axis[]):
     visibilities.push(c.active);
     names.push(c.label || `${index}`);
   });
+
+  if (greyscale && colors.length === 1) {
+    colors[0] = "FFFFFF";
+  }
 
   const defaultSelection = axes.map((axis) => {
     if (axis.type === "time") return t;


### PR DESCRIPTION
See https://github.com/ome/omero-blitz/issues/156

There are a fair number of images that have `omero` rendering settings with `rdefs.model: "greyscale"` and the single channel `color: "808080"` for various historical reasons (see issue above). 

These all render "grey" in vizarr which gives poor contrast.
E.g.:
 - https://hms-dbmi.github.io/vizarr/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0051/180712_H2B_22ss_Courtney1_20180712-163837_p00_c00_preview.zarr/0&viewState={%22target%22:[166.5,166.5],%22zoom%22:1.1004018969578375}
 - https://hms-dbmi.github.io/vizarr/?source=https://uk1s3.embassy.ebi.ac.uk/bia-integrator-data/S-BIAD1578/49b00ca0-bcbc-4527-b696-b3ddbde69504/b7e1824b-9b04-4052-b781-f41833de7407.ome.zarr/0
 - https://hms-dbmi.github.io/vizarr/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0083A/9822152.zarr


This PR adopts the logic in OMERO: if we have model of "greyscale" then render the 1 channel in white.
