### PR TITLE
Labels with single resolution image

### DIFF
--- a/src/components/LayerController/Labels.tsx
+++ b/src/components/LayerController/Labels.tsx
@@ -8,11 +8,11 @@ import { assert } from "../../utils";
 export default function Labels({ labelIndex }: { labelIndex: number }) {
   const [source] = useSourceData();
   const [layer, setLayer] = useLayerState();
-  assert(source.labels && layer.kind === "multiscale" && layer.labels, "Missing image labels");
+  assert(source.labels && layer.labels, "Missing image labels");
 
   const handleOpacityChange = (_: unknown, value: number | number[]) => {
     setLayer((prev) => {
-      assert(prev.kind === "multiscale" && prev.labels, "Missing image labels");
+      assert(prev.labels, "Missing image labels");
       return {
         ...prev,
         labels: prev.labels.with(labelIndex, {
@@ -43,7 +43,7 @@ export default function Labels({ labelIndex }: { labelIndex: number }) {
             style={{ backgroundColor: "transparent", padding: 0, zIndex: 2 }}
             onClick={() => {
               setLayer((prev) => {
-                assert(prev.kind === "multiscale" && prev.labels, "Missing image labels");
+                assert(prev.labels, "Missing image labels");
                 return {
                   ...prev,
                   labels: prev.labels.with(labelIndex, {

--- a/src/io.ts
+++ b/src/io.ts
@@ -208,17 +208,6 @@ export function initLayerStateFromSource(source: SourceData & { id: string }): L
     };
   }
 
-  if (source.loader.length === 1) {
-    return {
-      kind: "image",
-      layerProps: {
-        ...layerProps,
-        loader: source.loader[0],
-      },
-      on: true,
-    };
-  }
-
   let labels = undefined;
   if (source.labels && source.labels.length > 0) {
     labels = source.labels.map((label, i) => ({
@@ -232,6 +221,18 @@ export function initLayerStateFromSource(source: SourceData & { id: string }): L
         colors: label.colors,
       },
     }));
+  }
+
+  if (source.loader.length === 1) {
+    return {
+      kind: "image",
+      layerProps: {
+        ...layerProps,
+        loader: source.loader[0],
+      },
+      on: true,
+      labels,
+    };
   }
 
   return {


### PR DESCRIPTION
Digging into why labels at https://uk1s3.embassy.ebi.ac.uk/testbucket-bia/Diabetic_Biopsy_Human_Spectral_1-5300-2300_with_labels.ome.zarr/0 weren't showing up, it seems that labels are only displayed if the parent image has multiple dataset resolution levels (whereas that image only has a single resolution).

I don't know what the logic is there, but I made a couple of changes that allowed the labels to be displayed for that image.

