### PR TITLE
Make sure that CYMRGB is same length as MAX_CHANNELS

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,7 +21,7 @@ export const COLORS = {
 };
 export const MAGENTA_GREEN = [COLORS.magenta, COLORS.green];
 export const RGB = [COLORS.red, COLORS.green, COLORS.blue];
-export const CYMRGB = Object.values(COLORS).slice(0, -2);
+export const CYMRGB = Object.values(COLORS).slice(0, MAX_CHANNELS);
 export const OME_VALIDATOR_URL = "https://ome.github.io/ome-ngff-validator/";
 
 async function normalizeStore(source: string | zarr.Readable): Promise<zarr.Location<zarr.Readable>> {


### PR DESCRIPTION
This fixes a bug when viewing images that have no `omero` rendering metadata, and have more than `MAX_CHANNELS`.

In `getDefaultColors()` we have:

```
    // Set visible indices to CYMRGB colors. visibleIndices.length === MAX_CHANNELS from above.
    for (const [i, visibleIndex] of visibleIndices.entries()) {
      colors[visibleIndex] = CYMRGB[i];
    }
```
but the loop goes up to where `i` is `MAX_CHANNELS`. However, the length of `CYMRGB` is less than this, so when `i` is 6, then `CYMRGB[i]` is undefined.

This is fixed by slicing `CYMRBG` to be the same length as `MAX_CHANNELS`.

