### PR TITLE
Use defaultMeta in loadOmeMultiscales if no omero

### DIFF
--- a/src/io.ts
+++ b/src/io.ts
@@ -89,7 +89,7 @@ export async function createSourceData(config: ImageLayerConfig): Promise<Source
       return loadWell(config, node, attrs.well);
     }
 
-    if (utils.isOmeMultiscales(attrs)) {
+    if (utils.isMultiscales(attrs)) {
       return loadOmeMultiscales(config, node, attrs);
     }
 

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -253,7 +253,7 @@ export async function loadOmeMultiscales(
   const axes = utils.getNgffAxes(attrs.multiscales);
   const axis_labels = utils.getNgffAxisLabels(axes);
   const tileSize = utils.guessTileSize(data[0]);
-  let meta;
+  let meta: Meta;
   if (utils.isOmeMultiscales(attrs)) {
     meta = parseOmeroMeta(attrs.omero, axes);
   } else {


### PR DESCRIPTION
Fixes #297 

There is lots of useful logic in `loadOmeMultiscales()` such as handling labels and coordinateTransformations, but loadOmeMultiscales is currently skipped if the `omero` block isn't found.

This uses the `defaultMeta()` if `omero` isn't found, which means we can use `loadOmeMultiscales()` without testing for `omero`.

cc @dannda

Deployed at https://deploy-preview-298--vizarr.netlify.app/