### PR TITLE
Fix typo for scaleY calculation in fitImageToViewport

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -248,7 +248,7 @@ export function fitImageToViewport(options: {
     zoom: Math.log2(
       Math.min(
         availableWidth / (maxX - minX), // scaleX
-        availableHeight / (maxY - minX), // scaleY
+        availableHeight / (maxY - minY), // scaleY
       ),
     ),
     target: [(minX + maxX) / 2, (minY + maxY) / 2],


### PR DESCRIPTION
Became aware of this while testing the changes (https://github.com/hms-dbmi/vizarr/pull/298 and https://github.com/hms-dbmi/vizarr/pull/299) that originated from this issue: https://github.com/hms-dbmi/vizarr/issues/297 with larger datasets (which rendered correctly) and their flipped  counterparts (which also rendered correctly but initial display was off)

