### PR TITLE
Fix axis inference for multiscale groups without omero

### DIFF
--- a/__tests__/fixtures.json
+++ b/__tests__/fixtures.json
@@ -23425,5 +23425,171 @@
     "node_type": "array",
     "shape": [4, 25, 64, 64],
     "zarr_format": 3
-  }
+  },
+  "generated/plain-yx/.zgroup": {
+    "zarr_format": 2
+  },
+  "generated/plain-yx/.zattrs": {
+    "multiscales": [
+      {
+        "datasets": [
+          {
+            "path": "0"
+          },
+          {
+            "path": "1"
+          }
+        ],
+        "version": "0.1"
+      }
+    ]
+  },
+  "generated/plain-yx/0/.zarray": {
+    "shape": [1024, 1024],
+    "chunks": [256, 256],
+    "dtype": "|u1",
+    "fill_value": 0,
+    "order": "C",
+    "filters": null,
+    "compressor": {
+      "id": "blosc",
+      "cname": "lz4",
+      "clevel": 5,
+      "shuffle": 1,
+      "blocksize": 0
+    },
+    "zarr_format": 2
+  },
+  "generated/plain-yx/0/.zattrs": {},
+  "generated/plain-yx/1/.zarray": {
+    "shape": [512, 512],
+    "chunks": [256, 256],
+    "dtype": "|u1",
+    "fill_value": 0,
+    "order": "C",
+    "filters": null,
+    "compressor": {
+      "id": "blosc",
+      "cname": "lz4",
+      "clevel": 5,
+      "shuffle": 1,
+      "blocksize": 0
+    },
+    "zarr_format": 2
+  },
+  "generated/plain-yx/1/.zattrs": {},
+  "generated/plain-tyx/.zgroup": {
+    "zarr_format": 2
+  },
+  "generated/plain-tyx/.zattrs": {
+    "multiscales": [
+      {
+        "datasets": [
+          {
+            "path": "0"
+          },
+          {
+            "path": "1"
+          }
+        ],
+        "version": "0.1"
+      }
+    ]
+  },
+  "generated/plain-tyx/0/.zarray": {
+    "shape": [10, 512, 512],
+    "chunks": [1, 256, 256],
+    "dtype": "|u1",
+    "fill_value": 0,
+    "order": "C",
+    "filters": null,
+    "compressor": {
+      "id": "blosc",
+      "cname": "lz4",
+      "clevel": 5,
+      "shuffle": 1,
+      "blocksize": 0
+    },
+    "zarr_format": 2
+  },
+  "generated/plain-tyx/0/.zattrs": {},
+  "generated/plain-tyx/1/.zarray": {
+    "shape": [10, 256, 256],
+    "chunks": [1, 256, 256],
+    "dtype": "|u1",
+    "fill_value": 0,
+    "order": "C",
+    "filters": null,
+    "compressor": {
+      "id": "blosc",
+      "cname": "lz4",
+      "clevel": 5,
+      "shuffle": 1,
+      "blocksize": 0
+    },
+    "zarr_format": 2
+  },
+  "generated/plain-tyx/1/.zattrs": {},
+  "generated/plain-yx-with-axes/.zgroup": {
+    "zarr_format": 2
+  },
+  "generated/plain-yx-with-axes/.zattrs": {
+    "multiscales": [
+      {
+        "datasets": [
+          {
+            "path": "0"
+          },
+          {
+            "path": "1"
+          }
+        ],
+        "version": "0.4",
+        "axes": [
+          {
+            "name": "y",
+            "type": "space"
+          },
+          {
+            "name": "x",
+            "type": "space"
+          }
+        ]
+      }
+    ]
+  },
+  "generated/plain-yx-with-axes/0/.zarray": {
+    "shape": [1024, 1024],
+    "chunks": [256, 256],
+    "dtype": "|u1",
+    "fill_value": 0,
+    "order": "C",
+    "filters": null,
+    "compressor": {
+      "id": "blosc",
+      "cname": "lz4",
+      "clevel": 5,
+      "shuffle": 1,
+      "blocksize": 0
+    },
+    "zarr_format": 2
+  },
+  "generated/plain-yx-with-axes/0/.zattrs": {},
+  "generated/plain-yx-with-axes/1/.zarray": {
+    "shape": [512, 512],
+    "chunks": [256, 256],
+    "dtype": "|u1",
+    "fill_value": 0,
+    "order": "C",
+    "filters": null,
+    "compressor": {
+      "id": "blosc",
+      "cname": "lz4",
+      "clevel": 5,
+      "shuffle": 1,
+      "blocksize": 0
+    },
+    "zarr_format": 2
+  },
+  "generated/plain-yx-with-axes/1/.zattrs": {}
 }

--- a/__tests__/fixtures.test.ts
+++ b/__tests__/fixtures.test.ts
@@ -158,6 +158,12 @@ describe("classifySource", () => {
     assert(node instanceof zarr.Group);
     expect(classifySource(node, resolveAttrs(node.attrs)).kind).toMatchInlineSnapshot(`"multiscales"`);
   });
+
+  it("plain yx multiscale (no omero, no axes)", async () => {
+    const node = await openFixture("generated/plain-yx");
+    assert(node instanceof zarr.Group);
+    expect(classifySource(node, resolveAttrs(node.attrs)).kind).toMatchInlineSnapshot(`"multiscales"`);
+  });
 });
 
 describe("initLayerStateFromSource", () => {
@@ -281,6 +287,36 @@ describe("initLayerStateFromSource", () => {
       "multiscale | opacity=1 | colormap="" | on | axes=[t,c,z,y,x]
         ch 0  0                 ON   rgb(255,255,255)[1500,6000]   sel=[0,0,0,0,0]
         matrix: scale=[1.003,1.003,1.000]"
+    `);
+  });
+
+  it("plain yx multiscale (no omero, no axes) — infers 2D", async () => {
+    const source = await sourceDataFromFixture("generated/plain-yx");
+    const state = initLayerStateFromSource(source);
+    expect(formatLayerState(state, source)).toMatchInlineSnapshot(`
+      "multiscale | "Image" | opacity=1 | colormap="" | on | axes=[y,x]
+        ch 0  channel_0         ON   rgb(255,255,255)[0,255]       sel=[0,0]
+        matrix: none"
+    `);
+  });
+
+  it("plain tyx multiscale (no omero, no axes) — infers 3D", async () => {
+    const source = await sourceDataFromFixture("generated/plain-tyx");
+    const state = initLayerStateFromSource(source);
+    expect(formatLayerState(state, source)).toMatchInlineSnapshot(`
+      "multiscale | "Image" | opacity=1 | colormap="" | on | axes=[0,y,x]
+        ch 0  channel_0         ON   rgb(255,255,255)[0,255]       sel=[0,0,0]
+        matrix: none"
+    `);
+  });
+
+  it("plain yx with explicit axes — uses provided axes", async () => {
+    const source = await sourceDataFromFixture("generated/plain-yx-with-axes");
+    const state = initLayerStateFromSource(source);
+    expect(formatLayerState(state, source)).toMatchInlineSnapshot(`
+      "multiscale | "Image" | opacity=1 | colormap="" | on | axes=[y,x]
+        ch 0  channel_0         ON   rgb(255,255,255)[0,255]       sel=[0,0]
+        matrix: none"
     `);
   });
 });

--- a/scripts/fetch-fixtures.ts
+++ b/scripts/fetch-fixtures.ts
@@ -213,6 +213,79 @@ async function crawl(
   }
 }
 
+// ---------------------------------------------------------------------------
+// Synthetic fixtures — plain multiscale groups without omero metadata
+// ---------------------------------------------------------------------------
+
+function v2Array(shape: number[], chunks: number[]): Record<string, unknown> {
+  return {
+    shape,
+    chunks,
+    dtype: "|u1",
+    fill_value: 0,
+    order: "C",
+    filters: null,
+    compressor: { id: "blosc", cname: "lz4", clevel: 5, shuffle: 1, blocksize: 0 },
+    zarr_format: 2,
+  };
+}
+
+function plainMultiscale(
+  prefix: string,
+  levels: Array<{ shape: number[]; chunks: number[] }>,
+  attrs: Record<string, unknown>,
+): Record<string, Record<string, unknown>> {
+  const entries: Record<string, Record<string, unknown>> = {};
+  entries[`${prefix}/.zgroup`] = { zarr_format: 2 };
+  entries[`${prefix}/.zattrs`] = attrs;
+  for (let i = 0; i < levels.length; i++) {
+    entries[`${prefix}/${i}/.zarray`] = v2Array(levels[i].shape, levels[i].chunks);
+    entries[`${prefix}/${i}/.zattrs`] = {};
+  }
+  return entries;
+}
+
+const SYNTHETIC: Record<string, Record<string, unknown>> = {
+  // 2D multiscale, no omero, no axes (v0.1)
+  ...plainMultiscale(
+    "generated/plain-yx",
+    [
+      { shape: [1024, 1024], chunks: [256, 256] },
+      { shape: [512, 512], chunks: [256, 256] },
+    ],
+    { multiscales: [{ datasets: [{ path: "0" }, { path: "1" }], version: "0.1" }] },
+  ),
+  // 3D multiscale (t,y,x), no omero, no axes (v0.1)
+  ...plainMultiscale(
+    "generated/plain-tyx",
+    [
+      { shape: [10, 512, 512], chunks: [1, 256, 256] },
+      { shape: [10, 256, 256], chunks: [1, 256, 256] },
+    ],
+    { multiscales: [{ datasets: [{ path: "0" }, { path: "1" }], version: "0.1" }] },
+  ),
+  // 2D multiscale with explicit axes (v0.4), no omero
+  ...plainMultiscale(
+    "generated/plain-yx-with-axes",
+    [
+      { shape: [1024, 1024], chunks: [256, 256] },
+      { shape: [512, 512], chunks: [256, 256] },
+    ],
+    {
+      multiscales: [
+        {
+          datasets: [{ path: "0" }, { path: "1" }],
+          version: "0.4",
+          axes: [
+            { name: "y", type: "space" },
+            { name: "x", type: "space" },
+          ],
+        },
+      ],
+    },
+  ),
+};
+
 async function main() {
   const manifest: Record<string, unknown> = {};
 
@@ -221,8 +294,12 @@ async function main() {
     await crawl(url, name, 0, maxDepth, manifest);
   }
 
+  // Add synthetic fixtures
+  Object.assign(manifest, SYNTHETIC);
+  console.log(`\ngenerated/ (${Object.keys(SYNTHETIC).length} entries)`);
+
   await fs.writeFile(OUT_FILE, `${JSON.stringify(manifest, null, 2)}\n`);
-  console.log(`\nWrote ${Object.keys(manifest).length} entries to ${path.relative(process.cwd(), OUT_FILE)}`);
+  console.log(`Wrote ${Object.keys(manifest).length} entries to ${path.relative(process.cwd(), OUT_FILE)}`);
 }
 
 main().catch((err) => {

--- a/src/ome.ts
+++ b/src/ome.ts
@@ -284,11 +284,14 @@ export async function loadOmeMultiscales(
 ): Promise<SourceData> {
   const { name, opacity = 1, colormap = "" } = config;
   const data = await utils.loadMultiscales(grp, attrs.multiscales);
-  const axes = utils.getNgffAxes(attrs.multiscales);
-  const axis_labels = utils.getNgffAxisLabels(axes);
+  const hasExplicitAxes = !!attrs.multiscales[0]?.axes;
+  const isOme = utils.isOmeMultiscales(attrs);
+  // Use default 5D axes for OME-ZARR (has omero metadata), otherwise infer from shape
+  const axes = hasExplicitAxes || isOme ? utils.getNgffAxes(attrs.multiscales) : undefined;
+  const axis_labels = axes ? utils.getNgffAxisLabels(axes) : utils.getAxisLabels(data[0]);
   const tileSize = utils.guessTileSize(data[0]);
   let meta: Meta;
-  if (utils.isOmeMultiscales(attrs)) {
+  if (isOme && axes) {
     meta = parseOmeroMeta(attrs.omero, axes);
   } else {
     const lowresArray = data.at(-1);


### PR DESCRIPTION
`loadOmeMultiscales` always called `getNgffAxes` which defaults to 5D `[t, c, z, y, x]` when no explicit `axes` are present. This worked when every multiscale group had `omero` metadata, but plain multiscale stores (like a 2D generative pyramid) got the 5D default and rendered incorrectly with phantom channels and dimension sliders.

Now the 5D default only applies when the group has `omero` metadata. Without it, axis labels are inferred from the array shape, so a 2D array gets `[y, x]` and a 3D gets `[0, y, x]`.

Synthetic test fixtures for plain multiscale groups (yx, tyx, yx-with-axes) are generated alongside the fetched fixtures in `scripts/fetch-fixtures.ts`.